### PR TITLE
Add docs for barRadius

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ More details on available configuration can be found on their [wiki](https://git
 
 Example of how charts are used and how to apply configuration can be found in example.
 
+### Rounded bars
+
+Bar-based charts accept a `barRadius` prop that rounds the corners of the bars.
+The value is specified in **pixels** and currently only affects Android unless
+you provide an iOS implementation.
+
+```jsx
+<BarChart
+  style={{flex: 1}}
+  data={{/* data */}}
+  barRadius={8}
+/>
+```
+
+`HorizontalBarChart` and `CombinedChart` expose the same prop.
+
 
 
 ## Convention

--- a/docs.md
+++ b/docs.md
@@ -147,6 +147,7 @@
 | ------------------- | ------------------- | ------- | ---- |
 | `drawValueAboveBar` | `bool`              |         |      |
 | `drawBarShadow`     | `bool`              |         |      |
+| `barRadius`         | `number`            |         | Pixel radius of bar corners. Android only unless implemented for iOS. |
 | `data`              | `DataTypes.barData` |         |      |
 
 ## BubbleChart
@@ -173,6 +174,10 @@
 | ------      | ---------------------------------------------------- | ------- | ---- |
 | `data`      | `DataTypes.combinedData`                             |         |      |
 | `drawOrder` | `array with one of: ['SCATTER', 'BAR', 'LINE']`      |         |      |
+| `drawValueAboveBar` | `bool`              |         |      |
+| `highlightFullBarEnabled` | `bool`         |         |      |
+| `drawBarShadow`     | `bool`              |         |      |
+| `barRadius`         | `number`            |         | Pixel radius of bar corners. Android only unless implemented for iOS. |
 
 ## HorizontalBarChart
 
@@ -182,6 +187,7 @@
 | ------------------- | ------------------- | ------- | ---- |
 | `drawValueAboveBar` | `bool`              |         |      |
 | `drawBarShadow`     | `bool`              |         |      |
+| `barRadius`         | `number`            |         | Pixel radius of bar corners. Android only unless implemented for iOS. |
 | `data`              | `DataTypes.barData` |         |      |
 
 ## LineChart


### PR DESCRIPTION
## Summary
- document `barRadius` in README with example usage
- document `barRadius` prop for chart components

## Testing
- `git status --short`