### PR TITLE
Implement fading animation for Atflee marker

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -270,6 +270,9 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
     @ReactProp(name = "marker")
     public void setMarker(Chart chart, ReadableMap propMap) {
         if (!BridgeUtils.validate(propMap, ReadableType.Boolean, "enabled") || !propMap.getBoolean("enabled")) {
+            if (chart.getMarker() instanceof RNAtfleeMarkerView) {
+                ((RNAtfleeMarkerView) chart.getMarker()).resetState();
+            }
             chart.setMarker(null);
             return;
         }
@@ -286,6 +289,10 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
                 break;
             default:
                 markerView = rectangleMarker(chart, propMap);
+        }
+
+        if (chart.getMarker() instanceof RNAtfleeMarkerView) {
+            ((RNAtfleeMarkerView) chart.getMarker()).resetState();
         }
 
         markerView.setChartView(chart);
@@ -328,6 +335,10 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
         }
         if (BridgeUtils.validate(propMap, ReadableType.Number, "textSize")) {
             marker.getTvContent().setTextSize(propMap.getInt("textSize"));
+        }
+
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "fadeDuration")) {
+            marker.setFadeDuration((long) propMap.getDouble("fadeDuration"));
         }
 
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/markers/RNAtfleeMarkerView.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/markers/RNAtfleeMarkerView.java
@@ -22,17 +22,35 @@ public class RNAtfleeMarkerView extends MarkerView {
     private final TextView tvContent;
     private final ImageView imageEmotion;
 
+    /**
+     * Animation start timestamp and duration for fade out effect.
+     */
+    private long fadeStart = 0L;
+    private long fadeDuration = 0L;
+
+    public void setFadeDuration(long duration) {
+        this.fadeDuration = duration;
+    }
+
     public RNAtfleeMarkerView(Context context) {
         super(context, R.layout.atflee_marker);
 
         tvTitle = findViewById(R.id.x_value);
         tvContent = findViewById(R.id.y_value);
         imageEmotion = findViewById(R.id.image_emotion);
+
+        // Default fade duration (milliseconds)
+        fadeDuration = 300L;
     }
 
 
     @Override
     public void refreshContent(Entry e, Highlight highlight) {
+        if (fadeStart == 0L) {
+            fadeStart = System.currentTimeMillis();
+            setAlpha(1f);
+        }
+
         String decimalPlaces = "0";
         String markerUnit = "";
         String markerString = "";
@@ -115,6 +133,31 @@ public class RNAtfleeMarkerView extends MarkerView {
 
     public TextView getTvContent() {
         return tvContent;
+    }
+
+    @Override
+    public void draw(android.graphics.Canvas canvas) {
+        if (fadeDuration > 0 && fadeStart > 0) {
+            long elapsed = System.currentTimeMillis() - fadeStart;
+            if (elapsed < fadeDuration) {
+                float alpha = 1f - (float) elapsed / (float) fadeDuration;
+                setAlpha(alpha);
+                invalidate();
+            } else {
+                setAlpha(0f);
+            }
+        }
+        super.draw(canvas);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        resetState();
+    }
+
+    public void resetState() {
+        fadeStart = 0L;
     }
 
 }


### PR DESCRIPTION
## Summary
- add fade start/duration properties to `RNAtfleeMarkerView`
- animate opacity in `draw(Canvas)`
- expose setter for fade duration
- reset animation state when marker is removed or replaced
- wire new property in `ChartBaseManager`

## Testing
- `npm test` *(fails: Missing script)*
- `./gradlew test` *(fails: No such file or directory)*