### PR TITLE
Implement onMarkerClick support for Android

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -10,6 +10,8 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.common.MapBuilder;
+import javax.annotation.Nullable;
 import com.github.mikephil.charting.animation.Easing;
 import com.github.mikephil.charting.charts.Chart;
 import com.github.mikephil.charting.components.AxisBase;
@@ -37,6 +39,7 @@ import com.github.wuxudong.rncharts.utils.TypefaceUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends SimpleViewManager<T> {
@@ -671,6 +674,22 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
         chart.notifyDataSetChanged();
         onAfterDataSetChanged(chart);
         chart.postInvalidate();;
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> getExportedCustomBubblingEventTypeConstants() {
+        Map<String, Object> map = MapBuilder.of(
+                "topMarkerClick", MapBuilder.of(
+                        "phasedRegistrationNames",
+                        MapBuilder.of("bubbled", "onMarkerClick"))
+        );
+
+        Map<String, Object> existing = super.getExportedCustomBubblingEventTypeConstants();
+        if (existing != null) {
+            map.putAll(existing);
+        }
+        return map;
     }
 
 }

--- a/lib/BarChart.js
+++ b/lib/BarChart.js
@@ -38,7 +38,7 @@ BarChart.propTypes = {
 }
 
 var RNBarChart = requireNativeComponent('RNBarChart', BarChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 })
 
 export default ScrollEnhancer(HighlightEnhancer(ScaleEnhancer(MoveEnhancer(BarChart))))

--- a/lib/BubbleChart.js
+++ b/lib/BubbleChart.js
@@ -33,7 +33,7 @@ BubbleChart.propTypes = {
 };
 
 var RNBubbleChart = requireNativeComponent('RNBubbleChart', BubbleChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 });
 
 export default ScrollEnhancer(HighlightEnhancer(ScaleEnhancer(MoveEnhancer(BubbleChart))))

--- a/lib/CandleStickChart.js
+++ b/lib/CandleStickChart.js
@@ -34,7 +34,7 @@ CandleStickChart.propTypes = {
 };
 
 var RNCandleStickChart = requireNativeComponent('RNCandleStickChart', CandleStickChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 });
 
 export default ScrollEnhancer(HighlightEnhancer(ScaleEnhancer(MoveEnhancer(CandleStickChart))))

--- a/lib/CombinedChart.js
+++ b/lib/CombinedChart.js
@@ -38,7 +38,7 @@ CombinedChart.propTypes = {
 };
 
 var RNCombinedChart = requireNativeComponent('RNCombinedChart', CombinedChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 });
 
 export default ScrollEnhancer(HighlightEnhancer(ScaleEnhancer(MoveEnhancer(CombinedChart))))

--- a/lib/HorizontalBarChart.js
+++ b/lib/HorizontalBarChart.js
@@ -38,7 +38,7 @@ HorizontalBarChart.propTypes = {
 };
 
 var RNHorizontalBarChart = requireNativeComponent('RNHorizontalBarChart', HorizontalBarChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 });
 
 export default HighlightEnhancer(ScaleEnhancer(MoveEnhancer(HorizontalBarChart)))

--- a/lib/LineChart.js
+++ b/lib/LineChart.js
@@ -33,7 +33,7 @@ LineChart.propTypes = {
 };
 
 var RNLineChart = requireNativeComponent('RNLineChart', LineChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 });
 
 export default ScrollEnhancer(HighlightEnhancer(ScaleEnhancer(MoveEnhancer(LineChart))))

--- a/lib/PieChart.js
+++ b/lib/PieChart.js
@@ -58,7 +58,7 @@ PieChart.propTypes = {
 };
 
 var RNPieChart = requireNativeComponent('RNPieChart', PieChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 });
 
 export default PieChart

--- a/lib/RadarChart.js
+++ b/lib/RadarChart.js
@@ -46,7 +46,7 @@ RadarChart.propTypes = {
 };
 
 var RNRadarChart = requireNativeComponent('RNRadarChart', RadarChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 });
 
 export default RadarChart

--- a/lib/ScatterChart.js
+++ b/lib/ScatterChart.js
@@ -32,7 +32,7 @@ ScatterChart.propTypes = {
 };
 
 var RNScatterChart = requireNativeComponent('RNScatterChart', ScatterChart, {
-  nativeOnly: {onSelect: true, onChange: true}
+  nativeOnly: {onSelect: true, onChange: true, onMarkerClick: true}
 });
 
 export default ScrollEnhancer(HighlightEnhancer(ScaleEnhancer(MoveEnhancer(ScatterChart))))


### PR DESCRIPTION
## Summary
- add click support for RNAtfleeMarkerView and emit `topMarkerClick`
- export `onMarkerClick` bubbling event
- expose new nativeOnly prop on JS chart components

## Testing
- `npm test` *(fails: Missing script)*