### PR TITLE
Document barRadius in charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ Example of how charts are used and how to apply configuration can be found in ex
 ### Rounded bars
 
 Bar-based charts accept a `barRadius` prop that rounds the corners of the bars.
-The value is specified in **pixels** and currently only affects Android unless
-you provide an iOS implementation.
+When the value is greater than `0`, the chart switches to a rounded bar
+renderer. The radius value is specified in **pixels** and currently only
+affects Android unless you provide an iOS implementation.
 
 ```jsx
 <BarChart

--- a/docs.md
+++ b/docs.md
@@ -147,7 +147,7 @@
 | ------------------- | ------------------- | ------- | ---- |
 | `drawValueAboveBar` | `bool`              |         |      |
 | `drawBarShadow`     | `bool`              |         |      |
-| `barRadius`         | `number`            |         | Pixel radius of bar corners. Android only unless implemented for iOS. |
+| `barRadius`         | `number`            |         | Pixel radius of bar corners. When greater than `0`, a rounded bar renderer is used. Android only unless implemented for iOS. |
 | `data`              | `DataTypes.barData` |         |      |
 
 ## BubbleChart
@@ -177,7 +177,7 @@
 | `drawValueAboveBar` | `bool`              |         |      |
 | `highlightFullBarEnabled` | `bool`         |         |      |
 | `drawBarShadow`     | `bool`              |         |      |
-| `barRadius`         | `number`            |         | Pixel radius of bar corners. Android only unless implemented for iOS. |
+| `barRadius`         | `number`            |         | Pixel radius of bar corners. When greater than `0`, a rounded bar renderer is used. Android only unless implemented for iOS. |
 
 ## HorizontalBarChart
 
@@ -187,7 +187,7 @@
 | ------------------- | ------------------- | ------- | ---- |
 | `drawValueAboveBar` | `bool`              |         |      |
 | `drawBarShadow`     | `bool`              |         |      |
-| `barRadius`         | `number`            |         | Pixel radius of bar corners. Android only unless implemented for iOS. |
+| `barRadius`         | `number`            |         | Pixel radius of bar corners. When greater than `0`, a rounded bar renderer is used. Android only unless implemented for iOS. |
 | `data`              | `DataTypes.barData` |         |      |
 
 ## LineChart


### PR DESCRIPTION
## Summary
- document barRadius usage in README
- expand docs for BarChart, CombinedChart and HorizontalBarChart

## Testing
- `npm test` *(fails: Missing script)*