### PR TITLE
Fix rounded bar corner selection for negative values

### DIFF
--- a/ios/ReactNativeCharts/bar/RoundedBarChartRenderer.swift
+++ b/ios/ReactNativeCharts/bar/RoundedBarChartRenderer.swift
@@ -30,6 +30,8 @@ class RoundedBarChartRenderer: BarChartRenderer {
             guard let e = dataSet.entryForIndex(i) as? BarChartDataEntry else { continue }
             let x = e.x
             let y = e.y
+            let isPositive = y >= 0
+            let corners: UIRectCorner = isPositive ? [.topLeft, .topRight] : [.bottomLeft, .bottomRight]
 
             let left = x - barWidthHalf
             let right = x + barWidthHalf
@@ -55,7 +57,6 @@ class RoundedBarChartRenderer: BarChartRenderer {
             }
 
             context.setFillColor(dataSet.color(atIndex: i).cgColor)
-            let corners: UIRectCorner = e.y >= 0 ? [.topLeft, .topRight] : [.bottomLeft, .bottomRight]
             let path = UIBezierPath(
                 roundedRect: barRect,
                 byRoundingCorners: corners,

--- a/ios/ReactNativeCharts/bar/RoundedHorizontalBarChartRenderer.swift
+++ b/ios/ReactNativeCharts/bar/RoundedHorizontalBarChartRenderer.swift
@@ -29,6 +29,8 @@ class RoundedHorizontalBarChartRenderer: HorizontalBarChartRenderer {
             guard let e = dataSet.entryForIndex(i) as? BarChartDataEntry else { continue }
             let x = e.x
             let y = e.y
+            let isPositive = y >= 0
+            let corners: UIRectCorner = isPositive ? [.topRight, .bottomRight] : [.topLeft, .bottomLeft]
 
             var left = y >= 0.0 ? 0.0 : y
             var right = y <= 0.0 ? 0.0 : y
@@ -49,7 +51,6 @@ class RoundedHorizontalBarChartRenderer: HorizontalBarChartRenderer {
             }
 
             context.setFillColor(dataSet.color(atIndex: i).cgColor)
-            let corners: UIRectCorner = e.y >= 0 ? [.topRight, .bottomRight] : [.topLeft, .bottomLeft]
             let path = UIBezierPath(
                 roundedRect: barRect,
                 byRoundingCorners: corners,


### PR DESCRIPTION
## Summary
- ensure rounded corners are selected based on the sign of `e.y`
- do this for bar and horizontal bar renderers

## Testing
- `npm test` *(fails: Missing script)*