### PR TITLE
Fix CombinedChart renderer with DGCharts 5

### DIFF
--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -53,6 +53,7 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
 
         let chartFrame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
         chart.setExtraOffsets(left: 35, top: 5, right: 5, bottom: 5)
+        chart.viewPortHandler.setDragOffsetX(35)
         chart.reactSetFrame(chartFrame)
     }
 

--- a/ios/ReactNativeCharts/combine/RoundedCombinedChartRenderer.swift
+++ b/ios/ReactNativeCharts/combine/RoundedCombinedChartRenderer.swift
@@ -3,24 +3,49 @@ import DGCharts
 
 class RoundedCombinedChartRenderer: CombinedChartRenderer {
     var barRadius: CGFloat
+    private var roundedBarRenderer: RoundedBarChartRenderer?
 
     init(chart: CombinedChartView, animator: Animator, viewPortHandler: ViewPortHandler, barRadius: CGFloat) {
         self.barRadius = barRadius
         super.init(chart: chart, animator: animator, viewPortHandler: viewPortHandler)
-        self.barChartRenderer = RoundedBarChartRenderer(dataProvider: chart, animator: animator, viewPortHandler: viewPortHandler, radius: barRadius)
     }
 
     override func createRenderers() {
-        super.createRenderers()
-        self.barChartRenderer = RoundedBarChartRenderer(dataProvider: chart as! CombinedChartView, animator: animator, viewPortHandler: viewPortHandler, radius: barRadius)
+        renderers.removeAll()
+        roundedBarRenderer = nil
+
+        guard let chart = chart as? CombinedChartView else { return }
+
+        for order in chart.drawOrder {
+            switch order {
+            case .bar:
+                if chart.barData != nil {
+                    let renderer = RoundedBarChartRenderer(dataProvider: chart, animator: animator, viewPortHandler: viewPortHandler, radius: barRadius)
+                    roundedBarRenderer = renderer
+                    renderers.append(renderer)
+                }
+            case .bubble:
+                if chart.bubbleData != nil {
+                    renderers.append(BubbleChartRenderer(dataProvider: chart, animator: animator, viewPortHandler: viewPortHandler))
+                }
+            case .line:
+                if chart.lineData != nil {
+                    renderers.append(LineChartRenderer(dataProvider: chart, animator: animator, viewPortHandler: viewPortHandler))
+                }
+            case .candle:
+                if chart.candleData != nil {
+                    renderers.append(CandleStickChartRenderer(dataProvider: chart, animator: animator, viewPortHandler: viewPortHandler))
+                }
+            case .scatter:
+                if chart.scatterData != nil {
+                    renderers.append(ScatterChartRenderer(dataProvider: chart, animator: animator, viewPortHandler: viewPortHandler))
+                }
+            }
+        }
     }
 
     func setRadius(_ radius: CGFloat) {
         barRadius = radius
-        if let renderer = barChartRenderer as? RoundedBarChartRenderer {
-            renderer.setRadius(radius)
-        } else if let chart = chart as? CombinedChartView {
-            barChartRenderer = RoundedBarChartRenderer(dataProvider: chart, animator: animator, viewPortHandler: viewPortHandler, radius: radius)
-        }
+        roundedBarRenderer?.setRadius(radius)
     }
 }


### PR DESCRIPTION
## Summary
- remove direct barChartRenderer usage
- build renderers manually and store rounded renderer
- set default X-axis drag offset on iOS

## Testing
- `npm test` *(fails: Missing script)*