### PR TITLE
Fix Android marker click reset

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/markers/RNAtfleeMarkerView.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/markers/RNAtfleeMarkerView.java
@@ -232,7 +232,9 @@ public class RNAtfleeMarkerView extends MarkerView {
         reactContext.getJSModule(RCTEventEmitter.class)
                 .receiveEvent(chart.getId(), "topMarkerClick", event);
 
-        chart.highlightValue(null);
+        // Clear the current highlight without triggering listeners and
+        // then reset marker-related state as done on iOS.
+        chart.highlightValue(null, false);
         resetState();
     }
 


### PR DESCRIPTION
## Summary
- update `handleClick()` in `RNAtfleeMarkerView` to reset state after clearing highlight

## Testing
- `gradlew help` *(fails: No such file or directory)*