### PR TITLE
Fix draw order conversion in RoundedCombinedChartRenderer

### DIFF
--- a/ios/ReactNativeCharts/combine/RoundedCombinedChartRenderer.swift
+++ b/ios/ReactNativeCharts/combine/RoundedCombinedChartRenderer.swift
@@ -9,17 +9,18 @@ class RoundedCombinedChartRenderer: CombinedChartRenderer {
     init(chart: CombinedChartView, animator: Animator, viewPortHandler: ViewPortHandler, barRadius: CGFloat) {
         self.barRadius = barRadius
         super.init(chart: chart, animator: animator, viewPortHandler: viewPortHandler)
-        configureRenderers()
+        createRenderers()
     }
 
-    private func configureRenderers() {
+    override func createRenderers() {
         customRenderers.removeAll()
         roundedBarRenderer = nil
 
         guard let chart = chart as? CombinedChartView else { return }
 
         for order in chart.drawOrder {
-            switch order {
+            guard let drawOrder = CombinedChartView.DrawOrder(rawValue: order) else { continue }
+            switch drawOrder {
             case .bar:
                 if chart.barData != nil {
                     let renderer = RoundedBarChartRenderer(
@@ -101,6 +102,6 @@ class RoundedCombinedChartRenderer: CombinedChartRenderer {
 
     func setRadius(_ radius: CGFloat) {
         barRadius = radius
-        configureRenderers()
+        createRenderers()
     }
 }


### PR DESCRIPTION
## Summary
- handle `chart.drawOrder` elements as raw values
- rebuild renderer list using the converted draw order

## Testing
- `npm test` *(fails: Missing script)*