### PR TITLE
Update chart load event timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Triggered for various supported events on each platform. Due to the different na
 
 | Event Name | Description | iOS | Android |
 | --------------- | -------- | ------- | ---- |
-| `chartLoadComplete` | When the native chart finishes rendering. | ✅ | ✅ |
+| `chartLoadComplete` | When the native chart finishes its first render. | ✅ | ✅ |
 | `chartScaled`       | When a chart is scaled/zoomed via a pinch zoom gesture. | ✅ | ✅ |
 | `chartTranslated`   | When a chart is moved/translated via a drag gesture. | ✅ | ✅ |
 | `chartPanEnd`       | When a chart pan gesture ends. | ✅ | ❌ |

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -653,8 +653,9 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         chart.notifyDataSetChanged()
         onAfterDataSetChanged()
 
-        if !hasSentLoadComplete {
-            DispatchQueue.main.async {
+        if !hasSentLoadComplete && bounds.width > 0 && bounds.height > 0 {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
                 self.sendEvent("chartLoadComplete")
                 self.hasSentLoadComplete = true
             }


### PR DESCRIPTION
## Summary
- emit `chartLoadComplete` event only after first layout
- clarify when the event fires in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68414d0b6b1c83228f045a5b87c0b004