### PR TITLE
Update docs with chart callback example

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,18 @@ Triggered for various supported events on each platform. Due to the different na
 | `chartFling`        | When a chart recieves a fling gesture. | ❌ | ✅ |
 | `doubleTapped`      | When a chart is double tapped | ❌ | ✅ |
 
-
 check Example->MultipleChart for details.
+
+```jsx
+const handleChange = e => {
+  if (e.nativeEvent.action === 'chartLoadComplete') {
+    // chart is ready, e.nativeEvent.scaleX etc. are valid
+  }
+};
+<LineChart onChange={handleChange} ... />
+```
+
+Payload fields: `scaleX`, `scaleY`, `centerX`, `centerY`, `left`, `right`, `top`, `bottom`.
 
 ## Direct Function Call
 

--- a/docs.md
+++ b/docs.md
@@ -515,3 +515,16 @@ type combinedData {
   bubbleData: bubbleData
 }
 ```
+
+## Callbacks
+
+```jsx
+const handleChange = e => {
+  if (e.nativeEvent.action === 'chartLoadComplete') {
+    // chart is ready, e.nativeEvent.scaleX etc. are valid
+  }
+};
+<LineChart onChange={handleChange} ... />
+```
+
+Payload fields: `scaleX`, `scaleY`, `centerX`, `centerY`, `left`, `right`, `top`, `bottom`.


### PR DESCRIPTION
## Summary
- document `onChange` usage in README
- add callback details to docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68414d0a75f88322851426f84149b4d3