### PR TITLE
Ensure chartLoadComplete after render

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -739,23 +739,15 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
         chart.postInvalidate();
         Boolean sent = loadCompleteMap.get(chart);
         if (sent == null || !sent) {
-            chart.post(new Runnable() {
+            chart.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
                 @Override
-                public void run() {
-                    if (chart.getWidth() == 0 || chart.getHeight() == 0) {
-                        chart.getViewTreeObserver().addOnGlobalLayoutListener(new android.view.ViewTreeObserver.OnGlobalLayoutListener() {
-                            @Override
-                            public void onGlobalLayout() {
-                                chart.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                                sendLoadCompleteEvent(chart);
-                            }
-                        });
-                    } else {
-                        sendLoadCompleteEvent(chart);
-                    }
+                public boolean onPreDraw() {
+                    chart.getViewTreeObserver().removeOnPreDrawListener(this);
+                    sendLoadCompleteEvent(chart);
+                    loadCompleteMap.put(chart, true);
+                    return true;
                 }
             });
-            loadCompleteMap.put(chart, true);
         }
     }
 

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -53,10 +53,13 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         super.layoutSubviews()
 
         if !hasSentLoadComplete && bounds.width > 0 && bounds.height > 0 {
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                self.sendEvent("chartLoadComplete")
-                self.hasSentLoadComplete = true
+            DispatchQueue.main.async {
+                CATransaction.flush()
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    self.sendEvent("chartLoadComplete")
+                    self.hasSentLoadComplete = true
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- dispatch chartLoadComplete after next display cycle on iOS
- use a `ViewTreeObserver.OnPreDrawListener` to fire chartLoadComplete on Android

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68414d09534483228812a466da646622