### PR TITLE
Delay chart load complete event until after render

### DIFF
--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -54,7 +54,6 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
 
         if !hasSentLoadComplete && bounds.width > 0 && bounds.height > 0 {
             DispatchQueue.main.async {
-                CATransaction.flush()
                 DispatchQueue.main.async { [weak self] in
                     guard let self = self else { return }
                     self.sendEvent("chartLoadComplete")


### PR DESCRIPTION
## Summary
- ensure chart load completion fires after next run loop on iOS
- verify Android already waits for first draw using `OnPreDrawListener`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6841543ab2cc8322b14ea67e9e41138f