### PR TITLE
Enable drag-highlight on Android charts

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/AtfleeBarChart.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/AtfleeBarChart.java
@@ -26,6 +26,9 @@ public class AtfleeBarChart extends BarChart {
         // 양쪽 drag padding 추가
         mViewPortHandler.setDragOffsetX(30f);
 
+        // Highlight should follow finger drag similar to iOS
+        setHighlightPerDragEnabled(true);
+
         mRenderer = new AtfleeBarChartRenderer(this, mAnimator, mViewPortHandler);
 
         setHighlighter(new BarHighlighter(this));

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/AtfleeCombinedChart.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/AtfleeCombinedChart.java
@@ -34,6 +34,9 @@ public class AtfleeCombinedChart extends CombinedChart {
         // Old default behaviour
         setHighlightFullBarEnabled(true);
 
+        // Highlight should move with finger drag, matching iOS behaviour
+        setHighlightPerDragEnabled(true);
+
         // 양쪽 drag padding 추가
         mViewPortHandler.setDragOffsetX(35f);
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarChartManager.java
@@ -30,6 +30,9 @@ public class BarChartManager extends BarLineChartBaseManager<BarChart, BarEntry>
         );
         barChart.setXAxisRenderer(xRenderer);
 
+        // Enable marker dragging by default for consistency with iOS
+        barChart.setHighlightPerDragEnabled(true);
+
         return barChart;
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BubbleChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BubbleChartManager.java
@@ -21,6 +21,8 @@ public class BubbleChartManager extends BarLineChartBaseManager<BubbleChart, Bub
         BubbleChart bubbleChart =  new BubbleChart(reactContext);
         bubbleChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(bubbleChart));
         bubbleChart.setOnChartGestureListener(new RNOnChartGestureListener(bubbleChart));
+        // Enable marker dragging by default for consistency with iOS
+        bubbleChart.setHighlightPerDragEnabled(true);
         return bubbleChart;
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/CandleStickChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/CandleStickChartManager.java
@@ -20,6 +20,8 @@ public class CandleStickChartManager extends BarLineChartBaseManager<CandleStick
         CandleStickChart candleStickChart = new CandleStickChart(reactContext);
         candleStickChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(candleStickChart));
         candleStickChart.setOnChartGestureListener(new RNOnChartGestureListener(candleStickChart));
+        // Enable marker dragging by default for consistency with iOS
+        candleStickChart.setHighlightPerDragEnabled(true);
         return candleStickChart;
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/CombinedChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/CombinedChartManager.java
@@ -45,6 +45,8 @@ public class CombinedChartManager extends BarLineChartBaseManager<CombinedChart,
 //             parent.setClipChildren(false);
 //             parent.setClipToPadding(false);
 //         }
+        // Enable marker dragging by default for consistency with iOS
+        combinedChart.setHighlightPerDragEnabled(true);
         return combinedChart;
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/HorizontalBarChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/HorizontalBarChartManager.java
@@ -18,6 +18,8 @@ public class HorizontalBarChartManager extends BarChartManager {
         HorizontalBarChart horizontalBarChart = new HorizontalBarChart(reactContext);
         horizontalBarChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(horizontalBarChart));
         horizontalBarChart.setOnChartGestureListener(new RNOnChartGestureListener(horizontalBarChart));
+        // Enable marker dragging by default for consistency with iOS
+        horizontalBarChart.setHighlightPerDragEnabled(true);
         return horizontalBarChart;
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/LineChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/LineChartManager.java
@@ -30,7 +30,10 @@ public class LineChartManager extends BarLineChartBaseManager<LineChart, Entry> 
                 lineChart.getTransformer(YAxis.AxisDependency.LEFT)
         );
         lineChart.setXAxisRenderer(renderer);
-        
+
+        // Enable marker dragging by default for consistency with iOS
+        lineChart.setHighlightPerDragEnabled(true);
+
         return lineChart;
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ScatterChartManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ScatterChartManager.java
@@ -21,6 +21,8 @@ public class ScatterChartManager extends BarLineChartBaseManager<ScatterChart, E
         ScatterChart scatterChart = new ScatterChart(reactContext);
         scatterChart.setOnChartValueSelectedListener(new RNOnChartValueSelectedListener(scatterChart));
         scatterChart.setOnChartGestureListener(new RNOnChartGestureListener(scatterChart));
+        // Enable marker dragging by default for consistency with iOS
+        scatterChart.setHighlightPerDragEnabled(true);
         return scatterChart;
     }
 


### PR DESCRIPTION
## Summary
- make highlight follow finger by default in `AtfleeBarChart` and `AtfleeCombinedChart`
- enable `setHighlightPerDragEnabled(true)` for Android chart managers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6844081d61188322be92f104413185b0