### PR TITLE
Allow marker drag on Android

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/markers/RNAtfleeMarkerView.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/markers/RNAtfleeMarkerView.java
@@ -184,6 +184,19 @@ public class RNAtfleeMarkerView extends MarkerView {
                         handleClick();
                     }
                 });
+                // Forward drag events to the chart so the marker can move while
+                // swiping. Without this, the overlay view blocks touch events
+                // from reaching the chart, preventing highlight updates.
+                view.setOnTouchListener(new View.OnTouchListener() {
+                    @Override
+                    public boolean onTouch(View v, MotionEvent event) {
+                        Chart chartView = getChartView();
+                        if (chartView != null) {
+                            chartView.onTouchEvent(event);
+                        }
+                        return true; // consume so click listener still works
+                    }
+                });
 
                 ViewGroup.LayoutParams base = new ViewGroup.LayoutParams(getWidth(), getHeight());
                 if (parent instanceof android.widget.FrameLayout) {


### PR DESCRIPTION
## Summary
- fix overlay view blocking drag events when marker is visible on Android

## Testing
- `gradle test` *(fails: task not found)*

------
https://chatgpt.com/codex/tasks/task_b_684429f992fc8322bd45798eea420190