### PR TITLE
Clamp chart onChange bounds

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -125,9 +125,20 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
             MPPointD leftBottom = ((BarLineChartBase) chart).getValuesByTouchPoint(viewPortHandler.contentLeft(), viewPortHandler.contentBottom(), YAxis.AxisDependency.LEFT);
             MPPointD rightTop = ((BarLineChartBase) chart).getValuesByTouchPoint(viewPortHandler.contentRight(), viewPortHandler.contentTop(), YAxis.AxisDependency.LEFT);
 
-            event.putDouble("left", leftBottom.x);
+            float minX = chart.getData() != null ? chart.getData().getXMin() : Float.MIN_VALUE;
+            float maxX = chart.getData() != null ? chart.getData().getXMax() : Float.MAX_VALUE;
+
+            double leftValue = leftBottom.x;
+            double rightValue = rightTop.x;
+
+            if (leftValue < minX) leftValue = minX;
+            if (leftValue > maxX) leftValue = maxX;
+            if (rightValue < minX) rightValue = minX;
+            if (rightValue > maxX) rightValue = maxX;
+
+            event.putDouble("left", leftValue);
             event.putDouble("bottom", leftBottom.y);
-            event.putDouble("right", rightTop.x);
+            event.putDouble("right", rightValue);
             event.putDouble("top", rightTop.y);
 
             if (group != null && identifier != null) {

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -611,12 +611,22 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
                 dict["centerY"] = center.y
 
                 let leftBottom = barLineChart.valueForTouchPoint(point: CGPoint(x: handler.contentLeft, y: handler.contentBottom), axis: YAxis.AxisDependency.left)
-
                 let rightTop = barLineChart.valueForTouchPoint(point: CGPoint(x: handler.contentRight, y: handler.contentTop), axis: YAxis.AxisDependency.left)
 
-                dict["left"] = leftBottom.x
+                let minX = barLineChart.chartXMin
+                let maxX = barLineChart.chartXMax
+
+                var leftValue = leftBottom.x
+                var rightValue = rightTop.x
+
+                if leftValue < minX { leftValue = minX }
+                if leftValue > maxX { leftValue = maxX }
+                if rightValue < minX { rightValue = minX }
+                if rightValue > maxX { rightValue = maxX }
+
+                dict["left"] = leftValue
                 dict["bottom"] = leftBottom.y
-                dict["right"] = rightTop.x
+                dict["right"] = rightValue
                 dict["top"] = rightTop.y
 
                 if self.group != nil && self.identifier != nil {


### PR DESCRIPTION
## Summary
- prevent left/right over-scroll in Android onChange events
- clamp onChange data in iOS to chartXMin/chartXMax

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684452083c188322b77501bbedc2dbcb