### PR TITLE
Clamp viewport values at dataset boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ const handleChange = e => {
 ```
 
 Payload fields: `scaleX`, `scaleY`, `centerX`, `centerY`, `left`, `right`, `top`, `bottom`.
+`left` and `right` never exceed your dataset's X range and their distance is
+clamped to the width of the data to prevent jumps when you fling past the edges.
 
 ## Direct Function Call
 

--- a/docs.md
+++ b/docs.md
@@ -528,3 +528,5 @@ const handleChange = e => {
 ```
 
 Payload fields: `scaleX`, `scaleY`, `centerX`, `centerY`, `left`, `right`, `top`, `bottom`.
+`left` and `right` are clamped to the chart's data range and will never span
+beyond the dataset width, preventing spikes if you fling past the chart edges.

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -615,27 +615,34 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
 
                 let minX = barLineChart.chartXMin
                 let maxX = barLineChart.chartXMax
-                let dragOffset = handler.dragOffsetX
-
-                let allowedMin = minX - Double(dragOffset)
-                let allowedMax = maxX + Double(dragOffset)
+                // Constrain the range strictly to the actual data bounds.
+                // Using dragOffset here caused values outside of the data range
+                // to be emitted when overscrolling to the chart edges.
+                let allowedMin = minX
+                let allowedMax = maxX
 
                 let originalWidth = rightTop.x - leftBottom.x
+                let allowedWidth = allowedMax - allowedMin
                 var leftValue = leftBottom.x
                 var rightValue = rightTop.x
 
-                if leftValue < allowedMin {
+                if originalWidth > allowedWidth {
                     leftValue = allowedMin
-                    rightValue = leftValue + originalWidth
-                }
-
-                if rightValue > allowedMax {
                     rightValue = allowedMax
-                    leftValue = rightValue - originalWidth
-                }
+                } else {
+                    if leftValue < allowedMin {
+                        leftValue = allowedMin
+                        rightValue = leftValue + originalWidth
+                    }
 
-                if leftValue < allowedMin { leftValue = allowedMin }
-                if rightValue > allowedMax { rightValue = allowedMax }
+                    if rightValue > allowedMax {
+                        rightValue = allowedMax
+                        leftValue = rightValue - originalWidth
+                    }
+
+                    if leftValue < allowedMin { leftValue = allowedMin }
+                    if rightValue > allowedMax { rightValue = allowedMax }
+                }
 
                 dict["left"] = leftValue
                 dict["bottom"] = leftBottom.y


### PR DESCRIPTION
## Summary
- bound onChange `left` and `right` to dataset limits and limit width
- document clamping behaviour in README and docs

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_68446a4431748322ab6b38c94a3b53a1