### PR TITLE
Add native option for edge axis labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,47 @@ affects Android unless you provide an iOS implementation.
 
 `HorizontalBarChart` and `CombinedChart` expose the same prop.
 
+### Display xAxis labels only at the edges
+
+Sometimes you may want the x-axis to show labels only at the start and end of
+the visible range. Set `edgeLabelEnabled` to `true` to let the native layer
+automatically render labels only for the left and right edge. Internally a
+formatter checks the current viewport and hides the other labels.
+
+```jsx
+<LineChart
+  style={{flex: 1}}
+  xAxis={{
+    edgeLabelEnabled: true,
+  }}
+/>
+```
+
+If you need to handle this manually you can enable `granularity` and force the
+label count to two:
+
+```jsx
+<LineChart
+  style={{flex: 1}}
+  xAxis={{
+    granularityEnabled: true,
+    granularity: xLabelVisibleCount,
+    labelCount: 2,
+    labelCountForce: true,
+    avoidFirstLastClipping: true,
+  }}
+/>
+```
+
+Update `xLabelVisibleCount` when `showValueText` is `false` so that the axis
+labels appear only for the first and last entries:
+
+```javascript
+setXLabelVisibleCount(
+  showValueText ? defaultGranularity : chartValue.length - 1
+);
+```
+
 
 
 ## Convention

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -37,6 +37,8 @@ import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter;
 import com.github.mikephil.charting.formatter.LargeValueFormatter;
 import com.github.mikephil.charting.formatter.PercentFormatter;
+import com.github.mikephil.charting.formatter.ValueFormatter;
+import com.github.wuxudong.rncharts.charts.VisibleEdgeAxisValueFormatter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.wuxudong.rncharts.data.DataExtract;
 import com.github.wuxudong.rncharts.markers.RNAtfleeMarkerView;
@@ -310,6 +312,24 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
         }
         if (BridgeUtils.validate(propMap, ReadableType.String, "position")) {
             axis.setPosition(XAxisPosition.valueOf(propMap.getString("position")));
+        }
+
+        if (BridgeUtils.validate(propMap, ReadableType.Boolean, "edgeLabelEnabled")) {
+            boolean enabled = propMap.getBoolean("edgeLabelEnabled");
+            if (chart instanceof BarLineChartBase) {
+                BarLineChartBase barLineChart = (BarLineChartBase) chart;
+                ValueFormatter current = axis.getValueFormatter();
+                if (current instanceof VisibleEdgeAxisValueFormatter) {
+                    VisibleEdgeAxisValueFormatter vf = (VisibleEdgeAxisValueFormatter) current;
+                    if (enabled) {
+                        vf.setEnabled(true);
+                    } else {
+                        axis.setValueFormatter(vf.getBaseFormatter());
+                    }
+                } else if (enabled) {
+                    axis.setValueFormatter(new VisibleEdgeAxisValueFormatter(barLineChart, current, true));
+                }
+            }
         }
 
     }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/VisibleEdgeAxisValueFormatter.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/VisibleEdgeAxisValueFormatter.java
@@ -1,0 +1,44 @@
+package com.github.wuxudong.rncharts.charts;
+
+import com.github.mikephil.charting.charts.BarLineChartBase;
+import com.github.mikephil.charting.data.Entry;
+import com.github.mikephil.charting.formatter.ValueFormatter;
+
+public class VisibleEdgeAxisValueFormatter extends ValueFormatter {
+    private final BarLineChartBase chart;
+    private final ValueFormatter baseFormatter;
+    private boolean enabled;
+
+    public VisibleEdgeAxisValueFormatter(BarLineChartBase chart, ValueFormatter baseFormatter, boolean enabled) {
+        this.chart = chart;
+        this.baseFormatter = baseFormatter;
+        this.enabled = enabled;
+    }
+
+    public ValueFormatter getBaseFormatter() {
+        return baseFormatter;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public String getFormattedValue(float value) {
+        if (!enabled) {
+            return baseFormatter.getFormattedValue(value);
+        }
+        int leftIndex = Math.round(chart.getLowestVisibleX());
+        int rightIndex = Math.round(chart.getHighestVisibleX());
+        int index = Math.round(value);
+        if (index == leftIndex || index == rightIndex) {
+            return baseFormatter.getFormattedValue(value);
+        }
+        return "";
+    }
+
+    @Override
+    public String getPointLabel(Entry entry) {
+        return getFormattedValue(entry.getX());
+    }
+}

--- a/docs.md
+++ b/docs.md
@@ -74,6 +74,7 @@
 | ------------------------ | -------- | ------- | ---- |
 | `labelRotationAngle`     | `number` |         |      |
 | `avoidFirstLastClipping` | `bool`   |         |      |
+| `edgeLabelEnabled`       | `bool`   |         | Show only the left and right labels of the current view |
 | `position`               | `string` |         | Should be in upper case. you will get an error in android if the position is in lower case      |
 | `valueFormatterPattern`  | `string` |         |      |
 

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -300,6 +300,20 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         if json["position"].string != nil {
             xAxis.labelPosition = BridgeUtils.parseXAxisLabelPosition(json["position"].stringValue)
         }
+
+        if let barLine = chart as? BarLineChartViewBase, json["edgeLabelEnabled"].bool != nil {
+            let enable = json["edgeLabelEnabled"].boolValue
+            let current = xAxis.valueFormatter
+            if let edge = current as? VisibleEdgeAxisValueFormatter {
+                if enable {
+                    edge.enabled = true
+                } else {
+                    xAxis.valueFormatter = edge.base
+                }
+            } else if enable {
+                xAxis.valueFormatter = VisibleEdgeAxisValueFormatter(chart: barLine, base: current)
+            }
+        }
     }
 
     func setCommonAxisConfig(_ axis: AxisBase, config: JSON) {

--- a/ios/ReactNativeCharts/formatters/VisibleEdgeAxisValueFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/VisibleEdgeAxisValueFormatter.swift
@@ -1,0 +1,32 @@
+import Foundation
+import DGCharts
+
+@objc(VisibleEdgeAxisValueFormatter)
+open class VisibleEdgeAxisValueFormatter: NSObject, ValueFormatter, AxisValueFormatter {
+    weak var chart: BarLineChartViewBase?
+    var base: AxisValueFormatter
+    @objc public var enabled: Bool = true
+
+    @objc public init(chart: BarLineChartViewBase, base: AxisValueFormatter, enabled: Bool = true) {
+        self.chart = chart
+        self.base = base
+        self.enabled = enabled
+    }
+
+    open func stringForValue(_ value: Double, axis: AxisBase?) -> String {
+        guard enabled, let chart = chart else {
+            return base.stringForValue(value, axis: axis)
+        }
+        let leftIndex = Int(chart.lowestVisibleX.rounded())
+        let rightIndex = Int(chart.highestVisibleX.rounded())
+        let index = Int(value.rounded())
+        if index == leftIndex || index == rightIndex {
+            return base.stringForValue(value, axis: axis)
+        }
+        return ""
+    }
+
+    open func stringForValue(_ value: Double, entry: ChartDataEntry, dataSetIndex: Int, viewPortHandler: ViewPortHandler?) -> String {
+        return stringForValue(entry.x, axis: nil)
+    }
+}

--- a/lib/AxisIface.js
+++ b/lib/AxisIface.js
@@ -78,7 +78,10 @@ export const xAxisIface = {
   labelRotationAngle: PropTypes.number,
   avoidFirstLastClipping: PropTypes.bool,
   position: PropTypes.oneOf(['TOP', 'BOTTOM', 'BOTH_SIDED', 'TOP_INSIDE', 'BOTTOM_INSIDE']),
-  yOffset: PropTypes.number
+  yOffset: PropTypes.number,
+
+  // draw only the left and right labels of the visible x-axis range
+  edgeLabelEnabled: PropTypes.bool
 };
 
 export const yAxisIface = {


### PR DESCRIPTION
## Summary
- add `edgeLabelEnabled` xAxis prop to show only visible edge labels
- implement formatter logic on Android and iOS
- document the new property

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684ac3cbd83c8322b78ed8df12c48baf