### PR TITLE
Fix visible edge labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,9 @@ affects Android unless you provide an iOS implementation.
 Sometimes you may want the x-axis to show labels only at the start and end of
 the visible range. Set `edgeLabelEnabled` to `true` to let the native layer
 automatically render labels only for the left and right edge. Internally a
-formatter checks the viewport coordinates instead of relying on the chart's
-visible indices and hides the other labels. When the
-viewport edge falls between two values and the exact point is not visible,
-the formatter displays the previous value so that a label remains visible.
+formatter looks up the current viewport boundaries and hides the other
+labels. The edge labels always show the values at the exact start and end of
+the visible range so they update as you pan or zoom.
 
 ```jsx
 <LineChart

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/VisibleEdgeAxisValueFormatter.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/VisibleEdgeAxisValueFormatter.java
@@ -52,13 +52,15 @@ public class VisibleEdgeAxisValueFormatter extends ValueFormatter {
             return baseFormatter.getFormattedValue(value);
         }
 
-        int leftIndex = (int) Math.floor(lowest);
-
-        int rightIndex = (int) Math.ceil(highest);
+        int leftIndex = (int) Math.ceil(lowest);
+        int rightIndex = (int) Math.floor(highest);
 
         int index = Math.round(value);
-        if (index == leftIndex || index == rightIndex) {
-            return baseFormatter.getFormattedValue(value);
+        if (index == leftIndex) {
+            return baseFormatter.getFormattedValue(lowest);
+        }
+        if (index == rightIndex) {
+            return baseFormatter.getFormattedValue(highest);
         }
         return "";
     }

--- a/docs.md
+++ b/docs.md
@@ -74,7 +74,7 @@
 | ------------------------ | -------- | ------- | ---- |
 | `labelRotationAngle`     | `number` |         |      |
 | `avoidFirstLastClipping` | `bool`   |         |      |
-| `edgeLabelEnabled`       | `bool`   |         | Show only the left and right labels of the current view. The formatter derives the edge positions from viewport coordinates. If the edge does not land on an exact entry the previous value is used |
+| `edgeLabelEnabled`       | `bool`   |         | Show only the left and right labels of the current view. The formatter derives the labels from the visible viewport so they always reflect the exact boundary values |
 | `position`               | `string` |         | Should be in upper case. you will get an error in android if the position is in lower case      |
 | `valueFormatterPattern`  | `string` |         |      |
 

--- a/ios/ReactNativeCharts/formatters/VisibleEdgeAxisValueFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/VisibleEdgeAxisValueFormatter.swift
@@ -28,12 +28,15 @@ open class VisibleEdgeAxisValueFormatter: NSObject, ValueFormatter, AxisValueFor
             return base.stringForValue(value, axis: axis)
         }
 
-        let leftIndex = Int(floor(lowest))
-        let rightIndex = Int(ceil(highest))
+        let leftIndex = Int(ceil(lowest))
+        let rightIndex = Int(floor(highest))
 
         let index = Int(value.rounded())
-        if index == leftIndex || index == rightIndex {
-            return base.stringForValue(value, axis: axis)
+        if index == leftIndex {
+            return base.stringForValue(lowest, axis: axis)
+        }
+        if index == rightIndex {
+            return base.stringForValue(highest, axis: axis)
         }
         return ""
     }


### PR DESCRIPTION
## Summary
- show edge labels using the current viewport boundary values
- document that edge labels update with the viewport

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: package not present)*
- `yarn install` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_b_684ad4ee223c832287562fca535c686a