### PR TITLE
Add fixed edge label overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,12 @@ affects Android unless you provide an iOS implementation.
 
 `HorizontalBarChart` and `CombinedChart` expose the same prop.
 
-### Display xAxis labels only at the edges
+### Display fixed edge labels
 
-Sometimes you may want the x-axis to show labels only at the start and end of
-the visible range. Set `edgeLabelEnabled` to `true` to let the native layer
-automatically render labels only for the left and right edge. Internally a
-formatter looks up the current viewport boundaries and hides the other
-labels. The edge labels always show the values at the exact start and end of
-the visible range so they update as you pan or zoom.
+Enable `edgeLabelEnabled` to hide the regular x-axis labels and instead draw two
+fixed labels anchored to the left and right edges of the chart. The labels show
+the formatted values at the current visible range boundaries and update
+automatically as you pan or zoom.
 
 ```jsx
 <LineChart

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -34,11 +34,11 @@ import com.github.mikephil.charting.components.MarkerView;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.XAxis.XAxisPosition;
 import com.github.mikephil.charting.data.Entry;
+import com.github.wuxudong.rncharts.charts.helpers.EdgeLabelHelper;
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter;
 import com.github.mikephil.charting.formatter.LargeValueFormatter;
 import com.github.mikephil.charting.formatter.PercentFormatter;
 import com.github.mikephil.charting.formatter.ValueFormatter;
-import com.github.wuxudong.rncharts.charts.VisibleEdgeAxisValueFormatter;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.wuxudong.rncharts.data.DataExtract;
 import com.github.wuxudong.rncharts.markers.RNAtfleeMarkerView;
@@ -90,6 +90,8 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
                 event.putDouble("bottom", leftBottom.y);
                 event.putDouble("right", rightTop.x);
                 event.putDouble("top", rightTop.y);
+
+                EdgeLabelHelper.update(barLineChart, leftBottom.x, rightTop.x);
             }
         }
 
@@ -318,17 +320,8 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
             boolean enabled = propMap.getBoolean("edgeLabelEnabled");
             if (chart instanceof BarLineChartBase) {
                 BarLineChartBase barLineChart = (BarLineChartBase) chart;
-                ValueFormatter current = axis.getValueFormatter();
-                if (current instanceof VisibleEdgeAxisValueFormatter) {
-                    VisibleEdgeAxisValueFormatter vf = (VisibleEdgeAxisValueFormatter) current;
-                    if (enabled) {
-                        vf.setEnabled(true);
-                    } else {
-                        axis.setValueFormatter(vf.getBaseFormatter());
-                    }
-                } else if (enabled) {
-                    axis.setValueFormatter(new VisibleEdgeAxisValueFormatter(barLineChart, current, true));
-                }
+                axis.setDrawLabels(!enabled);
+                com.github.wuxudong.rncharts.charts.helpers.EdgeLabelHelper.setEnabled(barLineChart, enabled);
             }
         }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/VisibleEdgeAxisValueFormatter.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/VisibleEdgeAxisValueFormatter.java
@@ -53,14 +53,15 @@ public class VisibleEdgeAxisValueFormatter extends ValueFormatter {
         if (highest == lowest) {
             return baseFormatter.getFormattedValue(value);
         }
-        Log.d("index", "lowest: " + lowest + ", highest: " + highest);
         int leftIndex = (int) Math.ceil(lowest);
         int rightIndex = (int) Math.floor(highest);
-        Log.d("index", "leftIndex: " + leftIndex + ", rightIndex: " + rightIndex);
+
         int index = Math.round(value);
-        Log.d("index", "round: " + index);
-        if (index == leftIndex || index == rightIndex) {
-            return baseFormatter.getFormattedValue(value);
+        if (index == leftIndex) {
+            return baseFormatter.getFormattedValue(lowest);
+        }
+        if (index == rightIndex) {
+            return baseFormatter.getFormattedValue(highest);
         }
         return "";
     }

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/helpers/EdgeLabelHelper.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/helpers/EdgeLabelHelper.java
@@ -1,0 +1,87 @@
+package com.github.wuxudong.rncharts.charts.helpers;
+
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import com.github.mikephil.charting.charts.BarLineChartBase;
+import com.github.mikephil.charting.charts.Chart;
+import com.github.mikephil.charting.components.XAxis;
+import com.github.mikephil.charting.formatter.ValueFormatter;
+
+/** Helper for fixed edge labels overlayed on the chart. */
+public class EdgeLabelHelper {
+    private static String leftTag(Chart chart) {
+        return "edgeLabelLeft-" + chart.getId();
+    }
+    private static String rightTag(Chart chart) {
+        return "edgeLabelRight-" + chart.getId();
+    }
+
+    public static void setEnabled(BarLineChartBase chart, boolean enabled) {
+        ViewGroup parent = (ViewGroup) chart.getParent();
+        if (parent == null) return;
+
+        TextView left = parent.findViewWithTag(leftTag(chart));
+        TextView right = parent.findViewWithTag(rightTag(chart));
+
+        if (!enabled) {
+            if (left != null) parent.removeView(left);
+            if (right != null) parent.removeView(right);
+            return;
+        }
+
+        if (left == null) {
+            left = new TextView(chart.getContext());
+            FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+            lp.gravity = Gravity.START | Gravity.BOTTOM;
+            parent.addView(left, lp);
+            left.setTag(leftTag(chart));
+        }
+        if (right == null) {
+            right = new TextView(chart.getContext());
+            FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+            lp.gravity = Gravity.END | Gravity.BOTTOM;
+            parent.addView(right, lp);
+            right.setTag(rightTag(chart));
+        }
+
+        style(chart);
+    }
+
+    private static void style(BarLineChartBase chart) {
+        ViewGroup parent = (ViewGroup) chart.getParent();
+        if (parent == null) return;
+        TextView left = parent.findViewWithTag(leftTag(chart));
+        TextView right = parent.findViewWithTag(rightTag(chart));
+        if (left == null || right == null) return;
+
+        XAxis axis = chart.getXAxis();
+        int color = axis.getTextColor();
+        float size = axis.getTextSize();
+        left.setTextColor(color);
+        right.setTextColor(color);
+        left.setTextSize(TypedValue.COMPLEX_UNIT_PX, size);
+        right.setTextSize(TypedValue.COMPLEX_UNIT_PX, size);
+    }
+
+    public static void update(Chart chart, double leftValue, double rightValue) {
+        if (!(chart instanceof BarLineChartBase)) return;
+        BarLineChartBase bar = (BarLineChartBase) chart;
+        ViewGroup parent = (ViewGroup) bar.getParent();
+        if (parent == null) return;
+        TextView left = parent.findViewWithTag(leftTag(bar));
+        TextView right = parent.findViewWithTag(rightTag(bar));
+        if (left == null || right == null) return;
+
+        ValueFormatter vf = bar.getXAxis().getValueFormatter();
+        left.setText(vf.getFormattedValue((float) leftValue));
+        right.setText(vf.getFormattedValue((float) rightValue));
+    }
+}

--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -16,6 +16,7 @@ import com.github.mikephil.charting.listener.OnChartGestureListener;
 import com.github.mikephil.charting.utils.MPPointD;
 import com.github.mikephil.charting.utils.ViewPortHandler;
 import com.github.wuxudong.rncharts.charts.ChartGroupHolder;
+import com.github.wuxudong.rncharts.charts.helpers.EdgeLabelHelper;
 
 import java.lang.ref.WeakReference;
 
@@ -161,6 +162,8 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
             event.putDouble("bottom", leftBottom.y);
             event.putDouble("right", rightValue);
             event.putDouble("top", rightTop.y);
+
+            com.github.wuxudong.rncharts.charts.helpers.EdgeLabelHelper.update(chart, leftValue, rightValue);
 
             if (group != null && identifier != null) {
                 ChartGroupHolder.sync(group, identifier, chart.getScaleX(), chart.getScaleY(), (float) center.x, (float) center.y);

--- a/docs.md
+++ b/docs.md
@@ -74,7 +74,7 @@
 | ------------------------ | -------- | ------- | ---- |
 | `labelRotationAngle`     | `number` |         |      |
 | `avoidFirstLastClipping` | `bool`   |         |      |
-| `edgeLabelEnabled`       | `bool`   |         | Show only the left and right labels of the current view. The formatter derives the labels from the visible viewport so they always reflect the exact boundary values |
+| `edgeLabelEnabled`       | `bool`   |         | Hide normal x-axis labels and draw two fixed labels at the visible range edges. The labels update automatically as you scroll or zoom |
 | `position`               | `string` |         | Should be in upper case. you will get an error in android if the position is in lower case      |
 | `valueFormatterPattern`  | `string` |         |      |
 

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -39,6 +39,10 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
 
     open var onMarkerClick: RCTBubblingEventBlock?
 
+    private var leftEdgeLabel: UILabel?
+    private var rightEdgeLabel: UILabel?
+    private var edgeLabelEnabled: Bool = false
+
     private var group: String?
 
     private  var identifier: String?
@@ -303,16 +307,8 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
 
         if let barLine = chart as? BarLineChartViewBase, json["edgeLabelEnabled"].bool != nil {
             let enable = json["edgeLabelEnabled"].boolValue
-            let current = xAxis.valueFormatter
-            if let edge = current as? VisibleEdgeAxisValueFormatter {
-                if enable {
-                    edge.enabled = true
-                } else {
-                    xAxis.valueFormatter = edge.base
-                }
-            } else if enable {
-                xAxis.valueFormatter = VisibleEdgeAxisValueFormatter(chart: barLine, base: current)
-            }
+            xAxis.drawLabelsEnabled = !enable
+            configureEdgeLabels(enable)
         }
     }
 
@@ -607,6 +603,52 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         // 이건 좌우스크롤 highlightPerDragEnabled과 연관있으므로, 오버레이 터치 삭제하면 안됨
     }
 
+    private func configureEdgeLabels(_ enable: Bool) {
+        edgeLabelEnabled = enable
+        if enable {
+            if leftEdgeLabel == nil {
+                let label = UILabel()
+                label.translatesAutoresizingMaskIntoConstraints = false
+                addSubview(label)
+                label.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+                label.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+                leftEdgeLabel = label
+            }
+            if rightEdgeLabel == nil {
+                let label = UILabel()
+                label.translatesAutoresizingMaskIntoConstraints = false
+                addSubview(label)
+                label.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+                label.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+                rightEdgeLabel = label
+            }
+            applyEdgeLabelStyle()
+        } else {
+            leftEdgeLabel?.removeFromSuperview()
+            rightEdgeLabel?.removeFromSuperview()
+            leftEdgeLabel = nil
+            rightEdgeLabel = nil
+        }
+    }
+
+    private func applyEdgeLabelStyle() {
+        guard let barLine = chart as? BarLineChartViewBase else { return }
+        let axis = barLine.xAxis
+        let font = axis.labelFont
+        let color = axis.labelTextColor
+        leftEdgeLabel?.font = font
+        rightEdgeLabel?.font = font
+        leftEdgeLabel?.textColor = color
+        rightEdgeLabel?.textColor = color
+    }
+
+    private func updateEdgeLabels(left: Double, right: Double) {
+        guard edgeLabelEnabled, let barLine = chart as? BarLineChartViewBase else { return }
+        let formatter = barLine.xAxis.valueFormatter
+        leftEdgeLabel?.text = formatter.stringForValue(left, axis: barLine.xAxis)
+        rightEdgeLabel?.text = formatter.stringForValue(right, axis: barLine.xAxis)
+    }
+
     func sendEvent(_ action:String) {
         var dict = [AnyHashable: Any]()
 
@@ -658,6 +700,8 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
                 dict["bottom"] = leftBottom.y
                 dict["right"] = rightValue
                 dict["top"] = rightTop.y
+
+                updateEdgeLabels(left: leftValue, right: rightValue)
 
                 if self.group != nil && self.identifier != nil {
                     ChartGroupHolder.sync(group: self.group!, identifier: self.identifier!, scaleX: barLineChart.scaleX, scaleY: barLineChart.scaleY, centerX: center.x, centerY: center.y, performImmediately: true)

--- a/ios/ReactNativeCharts/formatters/VisibleEdgeAxisValueFormatter.swift
+++ b/ios/ReactNativeCharts/formatters/VisibleEdgeAxisValueFormatter.swift
@@ -32,8 +32,11 @@ open class VisibleEdgeAxisValueFormatter: NSObject, ValueFormatter, AxisValueFor
         let rightIndex = Int(ceil(highest))
 
         let index = Int(value.rounded())
-        if index == leftIndex || index == rightIndex {
-            return base.stringForValue(value, axis: axis)
+        if index == leftIndex {
+            return base.stringForValue(lowest, axis: axis)
+        }
+        if index == rightIndex {
+            return base.stringForValue(highest, axis: axis)
         }
         return ""
     }


### PR DESCRIPTION
## Summary
- hide xAxis labels when `edgeLabelEnabled` is true
- draw fixed left and right labels via native overlay views
- update docs to describe the new behavior

## Testing
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684add3297048322a224cea32da204de