### PR TITLE
Fix iOS zoom range when dataset smaller than visible range

### DIFF
--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -285,6 +285,10 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         barLineChart.data = dataExtract.extract(json)
         barLineChart.notifyDataSetChanged()
 
+        if let config = savedVisibleRange {
+            updateVisibleRange(config)
+        }
+
 
         let newVisibleXRange = barLineChart.visibleXRange
         let newVisibleYRange = getVisibleYRange(axis)
@@ -299,10 +303,6 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         // so in iOS, we updateVisibleRange after zoom
 
         barLineChart.zoom(scaleX: CGFloat(scaleX), scaleY: CGFloat(scaleY), xValue: Double(originCenterValue.x), yValue: Double(originCenterValue.y), axis: axis)
-
-        if let config = savedVisibleRange {
-            updateVisibleRange(config)
-        }
         barLineChart.notifyDataSetChanged()
 
         sendEvent("chartLoadComplete")


### PR DESCRIPTION
## Summary
- prevent tiny scale after data change on iOS

## Testing
- `npm test` *(fails: Missing script and cannot reach registry)*
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6850d33334688322b311f96d5b891829