### PR TITLE
Fix visibleRange handling with small datasets

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -10,6 +10,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
 import com.github.mikephil.charting.charts.BarLineChartBase;
 import com.github.mikephil.charting.charts.Chart;
 import com.github.mikephil.charting.components.YAxis;
+import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.jobs.ZoomJob;
 import com.github.mikephil.charting.listener.BarLineChartTouchListener;
@@ -114,7 +115,13 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
         if (BridgeUtils.validate(propMap, ReadableType.Map, "x")) {
             ReadableMap x = propMap.getMap("x");
             if (BridgeUtils.validate(x, ReadableType.Number, "min")) {
-                chart.setVisibleXRangeMinimum((float) x.getDouble("min"));
+                float min = (float) x.getDouble("min");
+                XAxis axis = chart.getXAxis();
+                float range = axis.getAxisMaximum() - axis.getAxisMinimum();
+                if (range < min) {
+                    axis.setAxisMaximum(axis.getAxisMinimum() + min);
+                }
+                chart.setVisibleXRangeMinimum(min);
             }
 
             if (BridgeUtils.validate(x, ReadableType.Number, "max")) {

--- a/docs.md
+++ b/docs.md
@@ -127,7 +127,7 @@
 | `borderWidth`            | `number`                                                                                                                                                        |         |      |
 | `minOffset`              | `number`                                                                                                                                                        |         |      |
 | `maxVisibleValueCount`   | `number`                                                                                                                                                        |         |      |
-| `visibleRange`           | `{`<br />`x: { min: number, max: number },`<br />`y: {`<br />`left: { min: number, max: number },`<br />`right: { min: number, max: number }`<br />`}`<br />`}` |         |      |
+| `visibleRange`           | `{`<br />`x: { min: number, max: number },`<br />`y: {`<br />`left: { min: number, max: number },`<br />`right: { min: number, max: number }`<br />`}`<br />`}` |         | If `x.min` exceeds the data range, the chart pads the x-axis so the zoom level remains unchanged. |
 | `autoScaleMinMaxEnabled` | `bool`                                                                                                                                                          |         |      |
 | `keepPositionOnRotation` | `bool`                                                                                                                                                          |         |      |
 | `scaleEnabled`           | `bool`                                                                                                                                                          |         |      |

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -118,7 +118,13 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
 
         let x = json["x"]
         if x["min"].double != nil {
-            barLineChart.setVisibleXRangeMinimum(x["min"].doubleValue)
+            let minRange = x["min"].doubleValue
+            let axis = barLineChart.xAxis
+            let currentRange = axis.axisMaximum - axis.axisMinimum
+            if currentRange < minRange {
+                axis.axisMaximum = axis.axisMinimum + minRange
+            }
+            barLineChart.setVisibleXRangeMinimum(minRange)
         }
         if x["max"].double != nil {
             barLineChart.setVisibleXRangeMaximum(x["max"].doubleValue)


### PR DESCRIPTION
## Summary
- ensure the x-axis does not shrink when the visible range minimum is larger than the dataset
- pad the x-axis on Android/iOS and update docs

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6850d33334688322b311f96d5b891829