### PR TITLE
Fix minimum visible range handling

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -114,7 +114,18 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
         if (BridgeUtils.validate(propMap, ReadableType.Map, "x")) {
             ReadableMap x = propMap.getMap("x");
             if (BridgeUtils.validate(x, ReadableType.Number, "min")) {
-                chart.setVisibleXRangeMinimum((float) x.getDouble("min"));
+                double min = x.getDouble("min");
+                int count = chart.getData() != null ? chart.getData().getEntryCount() : 0;
+                if (count > 0 && count < min) {
+                    XAxis xAxis = chart.getXAxis();
+                    float spaceMin = xAxis.getSpaceMin();
+                    float spaceMax = xAxis.getSpaceMax();
+                    float axisMin = chart.getXChartMin() - spaceMin;
+                    xAxis.setAxisMinimum(axisMin);
+                    xAxis.setAxisMaximum(axisMin + (float) min - 1 + spaceMin + spaceMax);
+                } else {
+                    chart.setVisibleXRangeMinimum((float) min);
+                }
             }
 
             if (BridgeUtils.validate(x, ReadableType.Number, "max")) {

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -117,11 +117,19 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         let json = BridgeUtils.toJson(config)
 
         let x = json["x"]
-        if x["min"].double != nil {
-            barLineChart.setVisibleXRangeMinimum(x["min"].doubleValue)
-        }
-        if x["max"].double != nil {
-            barLineChart.setVisibleXRangeMaximum(x["max"].doubleValue)
+        if let minVisible = x["min"].double, let data = barLineChart.data, data.entryCount < Int(minVisible) {
+            let spaceMin = barLineChart.xAxis.spaceMin
+            let spaceMax = barLineChart.xAxis.spaceMax
+            let axisMin = barLineChart.chartXMin - spaceMin
+            barLineChart.xAxis.axisMinimum = axisMin
+            barLineChart.xAxis.axisMaximum = axisMin + minVisible - 1 + spaceMin + spaceMax
+        } else {
+            if x["min"].double != nil {
+                barLineChart.setVisibleXRangeMinimum(x["min"].doubleValue)
+            }
+            if x["max"].double != nil {
+                barLineChart.setVisibleXRangeMaximum(x["max"].doubleValue)
+            }
         }
 
         let y = json["y"]


### PR DESCRIPTION
## Summary
- avoid shrinking zoom when dataset has fewer entries than `visibleRange.x.min`
- set axis bounds for short datasets to keep the same scale

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6850d33334688322b311f96d5b891829