### PR TITLE
Fix visible range calculation

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/AtfleeBarChart.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/AtfleeBarChart.java
@@ -33,7 +33,7 @@ public class AtfleeBarChart extends BarChart {
 
         setHighlighter(new BarHighlighter(this));
 
-        getXAxis().setSpaceMin(0.75f);
+        getXAxis().setSpaceMin(0f);
         getXAxis().setSpaceMax(0.75f);
     }
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/AtfleeCombinedChart.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/AtfleeCombinedChart.java
@@ -39,7 +39,7 @@ public class AtfleeCombinedChart extends CombinedChart {
 
         // 양쪽 drag padding 추가
         // mViewPortHandler.setDragOffsetX(35f);
-        getXAxis().setSpaceMin(0.75f);
+        getXAxis().setSpaceMin(0f);
         getXAxis().setSpaceMax(0.75f);
 
         mRenderer = new AtfleeCombinedChartRenderer(this, mAnimator, mViewPortHandler);

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -115,13 +115,7 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
         if (BridgeUtils.validate(propMap, ReadableType.Map, "x")) {
             ReadableMap x = propMap.getMap("x");
             if (BridgeUtils.validate(x, ReadableType.Number, "min")) {
-                float min = (float) x.getDouble("min");
-                XAxis axis = chart.getXAxis();
-                float range = axis.getAxisMaximum() - axis.getAxisMinimum();
-                if (range < min) {
-                    axis.setAxisMaximum(axis.getAxisMinimum() + min);
-                }
-                chart.setVisibleXRangeMinimum(min);
+                chart.setVisibleXRangeMinimum((float) x.getDouble("min"));
             }
 
             if (BridgeUtils.validate(x, ReadableType.Number, "max")) {

--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -138,7 +138,7 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
             float spaceMin = chart.getXAxis().getSpaceMin();
             float spaceMax = chart.getXAxis().getSpaceMax();
 
-            double allowedMin = minX - spaceMin;
+            double allowedMin = minX;
             double allowedMax = maxX + spaceMax;
 
             double originalWidth = rightTop.x - leftBottom.x;

--- a/docs.md
+++ b/docs.md
@@ -127,7 +127,7 @@
 | `borderWidth`            | `number`                                                                                                                                                        |         |      |
 | `minOffset`              | `number`                                                                                                                                                        |         |      |
 | `maxVisibleValueCount`   | `number`                                                                                                                                                        |         |      |
-| `visibleRange`           | `{`<br />`x: { min: number, max: number },`<br />`y: {`<br />`left: { min: number, max: number },`<br />`right: { min: number, max: number }`<br />`}`<br />`}` |         | If `x.min` exceeds the data range, the chart pads the x-axis so the zoom level remains unchanged. |
+| `visibleRange`           | `{`<br />`x: { min: number, max: number },`<br />`y: {`<br />`left: { min: number, max: number },`<br />`right: { min: number, max: number }`<br />`}`<br />`}` |         |      |
 | `autoScaleMinMaxEnabled` | `bool`                                                                                                                                                          |         |      |
 | `keepPositionOnRotation` | `bool`                                                                                                                                                          |         |      |
 | `scaleEnabled`           | `bool`                                                                                                                                                          |         |      |

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -118,13 +118,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
 
         let x = json["x"]
         if x["min"].double != nil {
-            let minRange = x["min"].doubleValue
-            let axis = barLineChart.xAxis
-            let currentRange = axis.axisMaximum - axis.axisMinimum
-            if currentRange < minRange {
-                axis.axisMaximum = axis.axisMinimum + minRange
-            }
-            barLineChart.setVisibleXRangeMinimum(minRange)
+            barLineChart.setVisibleXRangeMinimum(x["min"].doubleValue)
         }
         if x["max"].double != nil {
             barLineChart.setVisibleXRangeMaximum(x["max"].doubleValue)
@@ -283,8 +277,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
 
         let originCenterValue = barLineChart.valueForTouchPoint(point: CGPoint(x: contentRect.midX, y: contentRect.midY), axis: axis)
 
-        let originalSpace = barLineChart.xAxis.spaceMin + barLineChart.xAxis.spaceMax
-        let originalVisibleXRange = barLineChart.visibleXRange - originalSpace
+        let originalVisibleXRange = barLineChart.visibleXRange - barLineChart.xAxis.spaceMax
         let originalVisibleYRange = getVisibleYRange(axis)
 
         barLineChart.fitScreen()
@@ -296,8 +289,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
             updateVisibleRange(config)
         }
 
-        let newSpace = barLineChart.xAxis.spaceMin + barLineChart.xAxis.spaceMax
-        let newVisibleXRange = barLineChart.visibleXRange - newSpace
+        let newVisibleXRange = barLineChart.visibleXRange - barLineChart.xAxis.spaceMax
         let newVisibleYRange = getVisibleYRange(axis)
 
         var targetVisibleXRange = newVisibleXRange

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -82,7 +82,7 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         super.reactSetFrame(frame);
 
         let chartFrame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
-        chart.xAxis.spaceMin = 0.75
+        chart.xAxis.spaceMin = 0
         chart.xAxis.spaceMax = 0.75
         chart.reactSetFrame(chartFrame)
     }
@@ -752,10 +752,9 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
                 let maxX = barLineChart.chartXMax
                 // let dragOffset = handler.dragOffsetX
 
-                let spaceMin = barLineChart.xAxis.spaceMin
                 let spaceMax = barLineChart.xAxis.spaceMax
-                
-                let allowedMin = minX - spaceMin
+
+                let allowedMin = minX
                 let allowedMax = maxX + spaceMax
 
                 let originalWidth = rightTop.x - leftBottom.x


### PR DESCRIPTION
## Summary
- correct x range calculation on iOS so axis maximum isn't forced
- update docs for visibleRange prop
- mirror fix on Android so xRange minimum doesn't adjust axis
- only pad the right side of the x-axis

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_b_68511a1c65d08322b2f6e4095cba7aa7