### PR TITLE
Add xAxis spacing props

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ automatically as you pan or zoom. Padding is added on the sides and above the
 axis line so the text does not touch the chart edges. The chart automatically
 adds bottom padding equal to half the label height so the overlay never obstructs the
 data, and the helper keeps the values visible while scrolling or zooming.
+By default the x-axis reserves `0.75` units of spacing on each side. If you need
+to tweak this spacing for a custom layout, pass `spaceMin` and `spaceMax` in the
+`xAxis` config.
 
 ```jsx
 <LineChart

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -85,8 +85,14 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
 
                 MPPointD leftBottom = barLineChart.getValuesByTouchPoint(handler.contentLeft(), handler.contentBottom(), YAxis.AxisDependency.LEFT);
                 MPPointD rightTop = barLineChart.getValuesByTouchPoint(handler.contentRight(), handler.contentTop(), YAxis.AxisDependency.LEFT);
+
                 double leftValue = barLineChart.getLowestVisibleX();
                 double rightValue = barLineChart.getHighestVisibleX();
+
+                // Ignore extra x-axis spacing when reporting visible range
+                leftValue += barLineChart.getXAxis().getSpaceMin();
+                rightValue -= barLineChart.getXAxis().getSpaceMax();
+
                 event.putDouble("left", leftValue);
                 event.putDouble("bottom", leftBottom.y);
                 event.putDouble("right", rightValue);
@@ -315,6 +321,14 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
         }
         if (BridgeUtils.validate(propMap, ReadableType.String, "position")) {
             axis.setPosition(XAxisPosition.valueOf(propMap.getString("position")));
+        }
+
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "spaceMin")) {
+            axis.setSpaceMin((float) propMap.getDouble("spaceMin"));
+        }
+
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "spaceMax")) {
+            axis.setSpaceMax((float) propMap.getDouble("spaceMax"));
         }
 
         if (BridgeUtils.validate(propMap, ReadableType.Boolean, "edgeLabelEnabled")) {

--- a/docs.md
+++ b/docs.md
@@ -75,6 +75,8 @@
 | `labelRotationAngle`     | `number` |         |      |
 | `avoidFirstLastClipping` | `bool`   |         |      |
 | `edgeLabelEnabled`       | `bool`   |         | Hide normal x-axis labels and draw two padded labels at the visible range edges. The chart adds bottom padding equal to half the label height so they never overlap the data. The labels include top padding and update automatically as you scroll or zoom |
+| `spaceMin`               | `number` | 0.75    | Extra spacing on the left side of the x-axis |
+| `spaceMax`               | `number` | 0.75    | Extra spacing on the right side of the x-axis |
 | `position`               | `string` |         | Should be in upper case. you will get an error in android if the position is in lower case      |
 | `valueFormatterPattern`  | `string` |         |      |
 

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -314,6 +314,14 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
             xAxis.labelPosition = BridgeUtils.parseXAxisLabelPosition(json["position"].stringValue)
         }
 
+        if json["spaceMin"].number != nil {
+            xAxis.spaceMin = CGFloat(truncating: json["spaceMin"].numberValue)
+        }
+
+        if json["spaceMax"].number != nil {
+            xAxis.spaceMax = CGFloat(truncating: json["spaceMax"].numberValue)
+        }
+
         if let barLine = chart as? BarLineChartViewBase, json["edgeLabelEnabled"].bool != nil {
             let enable = json["edgeLabelEnabled"].boolValue
             xAxis.drawLabelsEnabled = !enable
@@ -752,6 +760,7 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
                 let maxX = barLineChart.chartXMax
                 // let dragOffset = handler.dragOffsetX
 
+                let spaceMin = barLineChart.xAxis.spaceMin
                 let spaceMax = barLineChart.xAxis.spaceMax
 
                 let allowedMin = minX
@@ -773,6 +782,11 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
 
                 if leftValue < allowedMin { leftValue = allowedMin }
                 if rightValue > allowedMax { rightValue = allowedMax }
+
+                if action == "chartLoadComplete" {
+                    leftValue += spaceMin
+                    rightValue -= spaceMax
+                }
 
                 dict["left"] = leftValue
                 dict["bottom"] = leftBottom.y

--- a/lib/AxisIface.js
+++ b/lib/AxisIface.js
@@ -79,6 +79,8 @@ export const xAxisIface = {
   avoidFirstLastClipping: PropTypes.bool,
   position: PropTypes.oneOf(['TOP', 'BOTTOM', 'BOTH_SIDED', 'TOP_INSIDE', 'BOTTOM_INSIDE']),
   yOffset: PropTypes.number,
+  spaceMin: PropTypes.number,
+  spaceMax: PropTypes.number,
 
   // draw only the left and right labels of the visible x-axis range
   edgeLabelEnabled: PropTypes.bool


### PR DESCRIPTION
## Summary
- support `spaceMin` and `spaceMax` props on xAxis to control extra spacing
- document new props and how to remove default spacing
- exclude x-axis spacing from `chartLoadComplete` event reporting

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68514cf297448322a82ac1cf9d344394