### PR TITLE
Clamp left boundary in gesture events

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ Triggered for various supported events on each platform. Due to the different na
 | --------------- | -------- | ------- | ---- |
 | `chartLoadComplete` | Fired after the chart renders or when zoom/visibleRange props update. | ✅ | ✅ |
 | `chartScaled`       | When a chart is scaled/zoomed via a pinch zoom gesture. | ✅ | ✅ |
-| `chartTranslated`   | When a chart is moved/translated via a drag gesture. | ✅ | ✅ |
-| `chartPanEnd`       | When a chart pan gesture ends. | ✅ | ❌ |
+| `chartTranslated`   | When a chart is moved/translated via a drag gesture. The `left` value is clamped to 0. | ✅ | ✅ |
+| `chartPanEnd`       | When a chart pan gesture ends. The `left` value is clamped to 0. | ✅ | ❌ |
 | `chartGestureStart` | When a chart gesture starts. | ❌ | ✅ |
 | `chartGestureEnd`   | When a chart gesture ends. | ❌ | ✅ |
 | `chartLongPress`    | When a chart is long pressed. | ❌ | ✅ |
@@ -251,6 +251,7 @@ const handleChange = e => {
 ```
 
 Payload fields: `scaleX`, `scaleY`, `centerX`, `centerY`, `left`, `right`, `top`, `bottom`.
+The `left` value reported by `chartTranslated` and `chartPanEnd` will never be below `0`.
 
 ## Direct Function Call
 

--- a/__tests__/sendEvent.test.js
+++ b/__tests__/sendEvent.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+function computeLeft(leftBottomX, rightTopX, minX, maxX, spaceMin, spaceMax) {
+  const allowedMin = minX - spaceMin;
+  const allowedMax = maxX + spaceMax;
+  const originalWidth = rightTopX - leftBottomX;
+  let leftValue = leftBottomX;
+  let rightValue = rightTopX;
+  if (leftValue < allowedMin) {
+    leftValue = allowedMin;
+    rightValue = leftValue + originalWidth;
+  }
+  if (rightValue > allowedMax) {
+    rightValue = allowedMax;
+    leftValue = rightValue - originalWidth;
+  }
+  if (leftValue < allowedMin) leftValue = allowedMin;
+  if (rightValue > allowedMax) rightValue = allowedMax;
+  if (leftValue < 0) leftValue = 0;
+  return leftValue;
+}
+
+assert.strictEqual(computeLeft(-5, 5, 0, 10, 0, 0) >= 0, true);
+console.log('All tests passed');

--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -158,6 +158,10 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
             if (leftValue < allowedMin) leftValue = allowedMin;
             if (rightValue > allowedMax) rightValue = allowedMax;
 
+            if (leftValue < 0) {
+                leftValue = 0;
+            }
+
             event.putDouble("left", leftValue);
             event.putDouble("bottom", leftBottom.y);
             event.putDouble("right", rightValue);

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -775,6 +775,10 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
                 if leftValue < allowedMin { leftValue = allowedMin }
                 if rightValue > allowedMax { rightValue = allowedMax }
 
+                if leftValue < 0 {
+                    leftValue = 0
+                }
+
                 dict["left"] = leftValue
                 dict["bottom"] = leftBottom.y
                 dict["right"] = rightValue


### PR DESCRIPTION
## Summary
- prevent negative `left` values in gesture event payloads on iOS and Android
- document the new clamping behavior
- add minimal test for sendEvent logic

## Testing
- `npm test` *(fails: Missing script)*
- `node __tests__/sendEvent.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68515978a7ec8322a8a9ca6a08f9ab55