### PR TITLE
Ensure proper chart event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,9 +248,12 @@ const handleChange = e => {
   }
 };
 <LineChart onChange={handleChange} ... />
+// visibleRange is applied only after the chart data is set. Listen for
+// `chartLoadComplete` to know when both visibleRange and zoom have taken effect.
 ```
 
 Payload fields: `scaleX`, `scaleY`, `centerX`, `centerY`, `left`, `right`, `top`, `bottom`.
+For `chartTranslated` and `chartPanEnd`, the `left` value is clamped to `0`.
 
 ## Direct Function Call
 

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -5,6 +5,10 @@ import android.graphics.RectF;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.github.mikephil.charting.charts.BarLineChartBase;
@@ -28,6 +32,8 @@ import javax.annotation.Nullable;
 
 class ChartExtraProperties {
     public ReadableMap savedVisibleRange = null;
+    public ReadableMap savedZoom = null;
+    public Float visibleRangeMin = null;
     public String group = null;
     public String identifier = null;
     public boolean syncX = true;
@@ -106,15 +112,28 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
     @ReactProp(name = "visibleRange")
     public void setVisibleXRangeMinimum(BarLineChartBase chart, ReadableMap propMap) {
         // delay visibleRange handling until chart data is set
-        extraPropertiesHolder.getExtraProperties(chart).savedVisibleRange = propMap;
+        ChartExtraProperties extras = extraPropertiesHolder.getExtraProperties(chart);
+        extras.savedVisibleRange = propMap;
+        if (BridgeUtils.validate(propMap, ReadableType.Map, "x")) {
+            ReadableMap x = propMap.getMap("x");
+            if (BridgeUtils.validate(x, ReadableType.Number, "min")) {
+                extras.visibleRangeMin = (float) x.getDouble("min");
+            } else {
+                extras.visibleRangeMin = null;
+            }
+        } else {
+            extras.visibleRangeMin = null;
+        }
 
     }
 
     private void updateVisibleRange(BarLineChartBase chart, ReadableMap propMap) {
+        ChartExtraProperties extras = extraPropertiesHolder.getExtraProperties(chart);
         if (BridgeUtils.validate(propMap, ReadableType.Map, "x")) {
             ReadableMap x = propMap.getMap("x");
             if (BridgeUtils.validate(x, ReadableType.Number, "min")) {
                 chart.setVisibleXRangeMinimum((float) x.getDouble("min"));
+                extras.visibleRangeMin = (float) x.getDouble("min");
             }
 
             if (BridgeUtils.validate(x, ReadableType.Number, "max")) {
@@ -147,8 +166,6 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
                 }
             }
         }
-
-        sendLoadCompleteEvent(chart);
     }
 
     @ReactProp(name = "autoScaleMinMaxEnabled")
@@ -202,22 +219,25 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
                 BridgeUtils.validate(propMap, ReadableType.Number, "scaleY") &&
                 BridgeUtils.validate(propMap, ReadableType.Number, "xValue") &&
                 BridgeUtils.validate(propMap, ReadableType.Number, "yValue")) {
-
-            YAxis.AxisDependency axisDependency = YAxis.AxisDependency.LEFT;
-            if (propMap.hasKey("axisDependency") &&
-                    propMap.getString("axisDependency").equalsIgnoreCase("RIGHT")) {
-                axisDependency = YAxis.AxisDependency.RIGHT;
-            }
-
-            chart.zoom(
-                    (float) propMap.getDouble("scaleX") / chart.getScaleX(),
-                    (float) propMap.getDouble("scaleY") / chart.getScaleY(),
-                    (float) propMap.getDouble("xValue"),
-                    (float) propMap.getDouble("yValue"),
-                    axisDependency
-            );
-            sendLoadCompleteEvent(chart);
+            ChartExtraProperties extras = extraPropertiesHolder.getExtraProperties(chart);
+            extras.savedZoom = propMap;
         }
+    }
+
+    private void applyZoom(BarLineChartBase chart, ReadableMap propMap) {
+        YAxis.AxisDependency axisDependency = YAxis.AxisDependency.LEFT;
+        if (propMap.hasKey("axisDependency") &&
+                propMap.getString("axisDependency").equalsIgnoreCase("RIGHT")) {
+            axisDependency = YAxis.AxisDependency.RIGHT;
+        }
+
+        chart.zoom(
+                (float) propMap.getDouble("scaleX") / chart.getScaleX(),
+                (float) propMap.getDouble("scaleY") / chart.getScaleY(),
+                (float) propMap.getDouble("xValue"),
+                (float) propMap.getDouble("yValue"),
+                axisDependency
+        );
     }
 
     // Note: Offset aren't updated until first touch event: https://github.com/PhilJay/MPAndroidChart/issues/892
@@ -399,10 +419,21 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
 
         ChartExtraProperties extraProperties = extraPropertiesHolder.getExtraProperties(chart);
 
+        boolean appliedRange = false;
         if (extraProperties.savedVisibleRange != null) {
             updateVisibleRange(chart, extraProperties.savedVisibleRange);
+            appliedRange = true;
         }
 
+        if (extraProperties.savedZoom != null) {
+            applyZoom(chart, extraProperties.savedZoom);
+            extraProperties.savedZoom = null;
+            appliedRange = true;
+        }
+
+        if (appliedRange) {
+            sendLoadCompleteEvent(chart);
+        }
 
         if (extraProperties.group != null && extraProperties.identifier != null) {
             OnChartGestureListener onChartGestureListener = chart.getOnChartGestureListener();
@@ -414,6 +445,53 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
             }
 
             ChartGroupHolder.addChart(extraProperties.group, extraProperties.identifier, chart, extraProperties.syncX, extraProperties.syncY);
+        }
+    }
+
+    @Override
+    protected void sendLoadCompleteEvent(Chart chart) {
+        if (chart instanceof BarLineChartBase) {
+            BarLineChartBase barLineChart = (BarLineChartBase) chart;
+            ChartExtraProperties extras = extraPropertiesHolder.getExtraProperties(barLineChart);
+            float scaleX = barLineChart.getScaleX();
+            if (extras.visibleRangeMin != null && extras.visibleRangeMin > 0) {
+                float dataRange = barLineChart.getXChartMax() - barLineChart.getXChartMin();
+                if (dataRange < extras.visibleRangeMin) {
+                    scaleX = dataRange / extras.visibleRangeMin;
+                }
+            }
+
+            WritableMap event = Arguments.createMap();
+            event.putString("action", "chartLoadComplete");
+            ViewPortHandler handler = chart.getViewPortHandler();
+            event.putDouble("scaleX", scaleX);
+            event.putDouble("scaleY", chart.getScaleY());
+
+            if (handler != null) {
+                MPPointD center = barLineChart.getValuesByTouchPoint(handler.getContentCenter().getX(), handler.getContentCenter().getY(), YAxis.AxisDependency.LEFT);
+                event.putDouble("centerX", center.x);
+                event.putDouble("centerY", center.y);
+
+                MPPointD leftBottom = barLineChart.getValuesByTouchPoint(handler.contentLeft(), handler.contentBottom(), YAxis.AxisDependency.LEFT);
+                MPPointD rightTop = barLineChart.getValuesByTouchPoint(handler.contentRight(), handler.contentTop(), YAxis.AxisDependency.LEFT);
+                double leftValue = barLineChart.getLowestVisibleX();
+                if (leftValue < 0) leftValue = 0;
+                double rightValue = barLineChart.getHighestVisibleX();
+                event.putDouble("left", leftValue);
+                event.putDouble("bottom", leftBottom.y);
+                event.putDouble("right", rightValue);
+                event.putDouble("top", rightTop.y);
+
+                EdgeLabelHelper.update(barLineChart, leftValue, rightValue);
+            }
+
+            if (chart.getContext() instanceof ReactContext) {
+                ReactContext reactContext = (ReactContext) chart.getContext();
+                reactContext.getJSModule(RCTEventEmitter.class)
+                        .receiveEvent(chart.getId(), "topChange", event);
+            }
+        } else {
+            super.sendLoadCompleteEvent(chart);
         }
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -157,6 +157,7 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
 
             if (leftValue < allowedMin) leftValue = allowedMin;
             if (rightValue > allowedMax) rightValue = allowedMax;
+            if (leftValue < 0) leftValue = 0;
 
             event.putDouble("left", leftValue);
             event.putDouble("bottom", leftBottom.y);

--- a/docs.md
+++ b/docs.md
@@ -127,7 +127,7 @@
 | `borderWidth`            | `number`                                                                                                                                                        |         |      |
 | `minOffset`              | `number`                                                                                                                                                        |         |      |
 | `maxVisibleValueCount`   | `number`                                                                                                                                                        |         |      |
-| `visibleRange`           | `{`<br />`x: { min: number, max: number },`<br />`y: {`<br />`left: { min: number, max: number },`<br />`right: { min: number, max: number }`<br />`}`<br />`}` |         |      |
+| `visibleRange`           | `{`<br />`x: { min: number, max: number },`<br />`y: {`<br />`left: { min: number, max: number },`<br />`right: { min: number, max: number }`<br />`}`<br />`}` |         |  Applied after chart data loads. Use `chartLoadComplete` to detect when zoom and visible range are fully applied. |
 | `autoScaleMinMaxEnabled` | `bool`                                                                                                                                                          |         |      |
 | `keepPositionOnRotation` | `bool`                                                                                                                                                          |         |      |
 | `scaleEnabled`           | `bool`                                                                                                                                                          |         |      |
@@ -526,6 +526,9 @@ const handleChange = e => {
   }
 };
 <LineChart onChange={handleChange} ... />
+// visibleRange is applied only after chart data is set. Use this event to know
+// when both visibleRange and zoom are active.
 ```
 
 Payload fields: `scaleX`, `scaleY`, `centerX`, `centerY`, `left`, `right`, `top`, `bottom`.
+`left` is never negative for `chartTranslated` and `chartPanEnd`.

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -18,6 +18,8 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
 
     var savedZoom : NSDictionary?
 
+    var visibleRangeMin: Double?
+
     var savedExtraOffsets: NSDictionary?
 
     var _onYaxisMinMaxChange : RCTBubblingEventBlock?
@@ -111,6 +113,11 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
     func setVisibleRange(_ config: NSDictionary) {
         // delay visibleRange handling until chart data is set
         savedVisibleRange = config
+        let json = BridgeUtils.toJson(config)
+        let x = json["x"]
+        if let min = x["min"].double {
+            visibleRangeMin = min
+        }
     }
 
     func updateVisibleRange(_ config: NSDictionary) {
@@ -119,6 +126,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         let x = json["x"]
         if x["min"].double != nil {
             barLineChart.setVisibleXRangeMinimum(x["min"].doubleValue)
+            visibleRangeMin = x["min"].doubleValue
         }
         if x["max"].double != nil {
             barLineChart.setVisibleXRangeMaximum(x["max"].doubleValue)
@@ -138,8 +146,6 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         if y["right"]["max"].double != nil {
             barLineChart.setVisibleYRangeMaximum(y["right"]["max"].doubleValue, axis: YAxis.AxisDependency.right)
         }
-
-        sendEvent("chartLoadComplete")
     }
 
     func setMaxScale(_ config: NSDictionary) {
@@ -258,13 +264,20 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         applyExtraOffsets()
 
         // clear zoom after applied, but keep visibleRange
+        var applied = false
         if let visibleRange = savedVisibleRange {
             updateVisibleRange(visibleRange)
+            applied = true
         }
 
         if let zoom = savedZoom {
             updateZoom(zoom)
             savedZoom = nil
+            applied = true
+        }
+
+        if applied {
+            sendEvent("chartLoadComplete")
         }
     }
 

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -736,7 +736,16 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
             let viewPortHandler = chart.viewPortHandler
             let barLineChart = chart as! BarLineChartViewBase
 
-            dict["scaleX"] = barLineChart.scaleX
+            var eventScaleX = barLineChart.scaleX
+            if action == "chartLoadComplete" {
+                if let bar = self as? RNBarLineChartViewBase, let min = bar.visibleRangeMin, min > 0 {
+                    let dataRange = barLineChart.chartXMax - barLineChart.chartXMin
+                    if dataRange < min {
+                        eventScaleX = dataRange / min
+                    }
+                }
+            }
+            dict["scaleX"] = eventScaleX
             dict["scaleY"] = barLineChart.scaleY
 
             if viewPortHandler != nil {
@@ -774,6 +783,7 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
 
                 if leftValue < allowedMin { leftValue = allowedMin }
                 if rightValue > allowedMax { rightValue = allowedMax }
+                if leftValue < 0 { leftValue = 0 }
 
                 dict["left"] = leftValue
                 dict["bottom"] = leftBottom.y


### PR DESCRIPTION
## Summary
- apply visibleRange before zoom and store zoom until data is ready
- keep `left` non-negative in gesture events
- compute load-complete scale for small datasets
- document visibleRange timing and clamped `left`

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: Internal Error)*

------
https://chatgpt.com/codex/tasks/task_b_685154651b4c8322aa0e592215a25760