### PR TITLE
Add minScale property

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -226,6 +226,17 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
         chart.setDoubleTapToZoomEnabled(enabled);
     }
 
+    @ReactProp(name = "minScale")
+    public void setMinScale(BarLineChartBase chart, ReadableMap propMap) {
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "x")) {
+            chart.getViewPortHandler().setMinimumScaleX((float) propMap.getDouble("x"));
+        }
+
+        if (BridgeUtils.validate(propMap, ReadableType.Number, "y")) {
+            chart.getViewPortHandler().setMinimumScaleY((float) propMap.getDouble("y"));
+        }
+    }
+
     @ReactProp(name = "zoom")
     public void setZoom(BarLineChartBase chart, ReadableMap propMap) {
         if (BridgeUtils.validate(propMap, ReadableType.Number, "scaleX") &&

--- a/docs.md
+++ b/docs.md
@@ -128,6 +128,7 @@
 | `minOffset`              | `number`                                                                                                                                                        |         |      |
 | `maxVisibleValueCount`   | `number`                                                                                                                                                        |         |      |
 | `visibleRange`           | `{`<br />`minimumSize: number,`<br />`x: { min: number, max: number },`<br />`y: {`<br />`left: { min: number, max: number },`<br />`right: { min: number, max: number }`<br />`}`<br />`}` |         |  Applied after chart data loads. Use `chartLoadComplete` to detect when zoom and visible range are fully applied. |
+| `minScale`               | `{`<br />`x: number,`<br />`y: number`<br />`}` |         |  Sets the minimum allowed zoom scale for each axis. |
 | `autoScaleMinMaxEnabled` | `bool`                                                                                                                                                          |         |      |
 | `keepPositionOnRotation` | `bool`                                                                                                                                                          |         |      |
 | `scaleEnabled`           | `bool`                                                                                                                                                          |         |      |

--- a/ios/ReactNativeCharts/RNBarLineChartManagerBridge.h
+++ b/ios/ReactNativeCharts/RNBarLineChartManagerBridge.h
@@ -16,6 +16,7 @@ RCT_EXPORT_VIEW_PROPERTY(borderWidth, CGFloat) \
 RCT_EXPORT_VIEW_PROPERTY(maxVisibleValueCount, NSInteger) \
 RCT_EXPORT_VIEW_PROPERTY(visibleRange, NSDictionary) \
 RCT_EXPORT_VIEW_PROPERTY(maxScale, NSDictionary) \
+RCT_EXPORT_VIEW_PROPERTY(minScale, NSDictionary) \
 RCT_EXPORT_VIEW_PROPERTY(autoScaleMinMaxEnabled, BOOL) \
 RCT_EXPORT_VIEW_PROPERTY(keepPositionOnRotation, BOOL) \
 RCT_EXPORT_VIEW_PROPERTY(scaleEnabled, BOOL) \

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -171,6 +171,20 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         }
     }
 
+    func setMinScale(_ config: NSDictionary) {
+        let json = BridgeUtils.toJson(config)
+
+        let minScaleX = json["x"]
+        if minScaleX.double != nil {
+            barLineChart.viewPortHandler.setMinimumScaleX(minScaleX.doubleValue)
+        }
+
+        let minScaleY = json["y"]
+        if minScaleY.double != nil {
+            barLineChart.viewPortHandler.setMinimumScaleY(minScaleY.doubleValue)
+        }
+    }
+
     func setAutoScaleMinMaxEnabled(_  enabled: Bool) {
         barLineChart.autoScaleMinMaxEnabled = enabled
     }

--- a/lib/BarLineChartBase.js
+++ b/lib/BarLineChartBase.js
@@ -40,6 +40,10 @@ const iface = {
       x: PropTypes.number,
       y: PropTypes.number
     }),
+    minScale: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number
+    }),
     autoScaleMinMaxEnabled: PropTypes.bool,
     keepPositionOnRotation: PropTypes.bool,
 


### PR DESCRIPTION
## Summary
- expose `minScale` prop for controlling minimum zoom level
- implement on iOS and Android
- document new prop

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_b_68516eca459083229c86c93899fb601e