### PR TITLE
Fix iOS zoom order

### DIFF
--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -241,8 +241,6 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
                     xValue: json["xValue"].doubleValue,
                     yValue: json["yValue"].doubleValue,
                     axis: axisDependency)
-
-            sendEvent("chartLoadComplete")
         }
     }
 
@@ -288,14 +286,14 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
 
         // clear zoom after applied, but keep visibleRange
         var applied = false
-        if let visibleRange = savedVisibleRange {
-            updateVisibleRange(visibleRange)
-            applied = true
-        }
-
         if let zoom = savedZoom {
             updateZoom(zoom)
             savedZoom = nil
+            applied = true
+        }
+
+        if let visibleRange = savedVisibleRange {
+            updateVisibleRange(visibleRange)
             applied = true
         }
 


### PR DESCRIPTION
## Summary
- fix zoom handler to not emit loadComplete itself
- apply zoom before visibleRange on iOS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68517a1c05048322920818e6f6679a2e