### PR TITLE
Fix initial zoom scale priority

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -59,8 +59,6 @@ class ExtraPropertiesHolder {
 
 public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U extends Entry> extends YAxisChartBase<T, U> {
 
-    private static final float PREDEFINED_SCALE = 0.5f;
-
     private ExtraPropertiesHolder extraPropertiesHolder = new ExtraPropertiesHolder();
 
     @Override
@@ -478,16 +476,7 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
     protected void sendLoadCompleteEvent(Chart chart) {
         if (chart instanceof BarLineChartBase) {
             BarLineChartBase barLineChart = (BarLineChartBase) chart;
-            ChartExtraProperties extras = extraPropertiesHolder.getExtraProperties(barLineChart);
             float scaleX = barLineChart.getScaleX();
-            if (extras.visibleRangeMin != null && extras.visibleRangeMin > 0) {
-                float dataRange = barLineChart.getXChartMax() - barLineChart.getXChartMin();
-                if (dataRange < extras.visibleRangeMin) {
-                    scaleX = dataRange / extras.visibleRangeMin;
-                } else if (extras.minimumSize != null && extras.minimumSize.equals(extras.visibleRangeMin)) {
-                    scaleX = PREDEFINED_SCALE;
-                }
-            }
 
             WritableMap event = Arguments.createMap();
             event.putString("action", "chartLoadComplete");

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -21,8 +21,6 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
     var visibleRangeMin: Double?
     var minimumSize: Double?
 
-    static let PREDEFINED_SCALE: CGFloat = 0.5
-
     var savedExtraOffsets: NSDictionary?
 
     private var hasSentLoadCompleteEvent = false

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -736,17 +736,7 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
             let viewPortHandler = chart.viewPortHandler
             let barLineChart = chart as! BarLineChartViewBase
 
-            var eventScaleX = barLineChart.scaleX
-            if action == "chartLoadComplete" {
-                if let bar = self as? RNBarLineChartViewBase, let min = bar.visibleRangeMin, min > 0 {
-                    let dataRange = barLineChart.chartXMax - barLineChart.chartXMin
-                    if dataRange < min {
-                        eventScaleX = dataRange / min
-                    } else if let minimumSize = bar.minimumSize, minimumSize == min {
-                        eventScaleX = RNBarLineChartViewBase.PREDEFINED_SCALE
-                    }
-                }
-            }
+            let eventScaleX = barLineChart.scaleX
             dict["scaleX"] = eventScaleX
             dict["scaleY"] = barLineChart.scaleY
 


### PR DESCRIPTION
## Summary
- remove PREDEFINED_SCALE override for chartLoadComplete event on Android
- remove PREDEFINED_SCALE override for chartLoadComplete event on iOS
- update iOS and Android chart managers to always report the real zoom scale

## Testing
- `node __tests__/sendEvent.test.js`

------
https://chatgpt.com/codex/tasks/task_b_6851935b0ab4832295a9dccebf689ad4