### PR TITLE
Fix negative left offsets

### DIFF
--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -220,7 +220,8 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
     func setViewPortOffsets(_ config: NSDictionary) {
         let json = BridgeUtils.toJson(config)
 
-        let left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
+        var left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
+        if left < 0 { left = 0 }
         let top = json["top"].double != nil ? CGFloat(json["top"].doubleValue) : 0
         let right = json["right"].double != nil ? CGFloat(json["right"].doubleValue) : 0
         let bottom = json["bottom"].double != nil ? CGFloat(json["bottom"].doubleValue) : 0
@@ -241,6 +242,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
         if let config = savedExtraOffsets {
             let json = BridgeUtils.toJson(config)
             left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
+            if left < 0 { left = 0 }
             top = json["top"].double != nil ? CGFloat(json["top"].doubleValue) : 0
             right = json["right"].double != nil ? CGFloat(json["right"].doubleValue) : 0
             bottom = json["bottom"].double != nil ? CGFloat(json["bottom"].doubleValue) : 0

--- a/ios/ReactNativeCharts/pie/RNPieChartView.swift
+++ b/ios/ReactNativeCharts/pie/RNPieChartView.swift
@@ -139,6 +139,7 @@ class RNPieChartView: RNChartViewBase {
         if json["left"].float != nil
         {
             leftOffset = CGFloat(json["left"].floatValue)
+            if leftOffset < 0 { leftOffset = 0 }
         }
         if json["top"].float != nil
         {

--- a/ios/ReactNativeCharts/radar/RNRadarChartView.swift
+++ b/ios/ReactNativeCharts/radar/RNRadarChartView.swift
@@ -52,7 +52,8 @@ class RNRadarChartView: RNYAxisChartViewBase {
     func setExtraOffsets(_ config: NSDictionary) {
       let json = BridgeUtils.toJson(config)
 
-      let left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
+      var left = json["left"].double != nil ? CGFloat(json["left"].doubleValue) : 0
+      if left < 0 { left = 0 }
       let top = json["top"].double != nil ? CGFloat(json["top"].doubleValue) : 0
       let right = json["right"].double != nil ? CGFloat(json["right"].doubleValue) : 0
       let bottom = json["bottom"].double != nil ? CGFloat(json["bottom"].doubleValue) : 0


### PR DESCRIPTION
## Summary
- prevent negative values for left viewport offsets in iOS chart views
- clamp left extra offsets in radar and pie charts

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68520bb57f148322936b023c07334541