### PR TITLE
Fix newline edge label clipping

### DIFF
--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -671,9 +671,10 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         leftEdgeLabel?.lineBreakMode = .byWordWrapping
         rightEdgeLabel?.lineBreakMode = .byWordWrapping
         
-        if ((leftEdgeLabel?.text?.contains("\n")) ?? false || (rightEdgeLabel?.text?.contains("\n")) ?? false) {
-            leftEdgeConstraint?.constant = -(font.lineHeight + 15)
-            rightEdgeConstraint?.constant = -(font.lineHeight + 15)
+        let height = edgeLabelHeight()
+        if height > 0 {
+            leftEdgeConstraint?.constant = -height
+            rightEdgeConstraint?.constant = -height
         } else {
             leftEdgeConstraint?.constant = -(font.lineHeight)
             rightEdgeConstraint?.constant = -(font.lineHeight)


### PR DESCRIPTION
## Summary
- handle multiline edge labels so they're not clipped

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68638979077c8322b34f6c4cd3ccd03f