### PR TITLE
Handle multi-line xAxis labels

### DIFF
--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -248,10 +248,25 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
             bottom = json["bottom"].double != nil ? CGFloat(json["bottom"].doubleValue) : 0
         }
         if edgeLabelEnabled {
-            let axisHeight = barLineChart.xAxis.labelFont.lineHeight / 2
+            var axisHeight = barLineChart.xAxis.labelFont.lineHeight / 2
+            if xAxisContainsNewline() {
+                axisHeight = barLineChart.xAxis.labelFont.lineHeight
+            }
             bottom = axisHeight + edgeLabelHeight()// + edgeLabelTopPadding
         }
         barLineChart.setExtraOffsets(left: left, top: top, right: right, bottom: bottom)
+    }
+
+    private func xAxisContainsNewline() -> Bool {
+        let axis = barLineChart.xAxis
+        guard let formatter = axis.valueFormatter else { return false }
+        let maxIdx = Int(axis.axisMaximum)
+        for i in 0..<maxIdx {
+            if formatter.stringForValue(Double(i), axis: axis).contains("\n") {
+                return true
+            }
+        }
+        return false
     }
 
     override func onAfterDataSetChanged() {

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -671,15 +671,16 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         leftEdgeLabel?.lineBreakMode = .byWordWrapping
         rightEdgeLabel?.lineBreakMode = .byWordWrapping
         
-        if ((leftEdgeLabel?.text?.contains("\n")) ?? false || (rightEdgeLabel?.text?.contains("\n")) ?? false) {
-            leftEdgeConstraint?.constant = -(font.lineHeight + 15)
-            rightEdgeConstraint?.constant = -(font.lineHeight + 15)
+        // Ensure new text has updated intrinsic size before computing height
+        layoutIfNeeded()
+        let height = edgeLabelHeight()
+        if height > 0 {
+            leftEdgeConstraint?.constant = -height
+            rightEdgeConstraint?.constant = -height
         } else {
             leftEdgeConstraint?.constant = -(font.lineHeight)
             rightEdgeConstraint?.constant = -(font.lineHeight)
         }
-        
-        layoutIfNeeded()
     }
 
     func edgeLabelHeight() -> CGFloat {


### PR DESCRIPTION
## Summary
- adjust extra bottom offset when xAxis labels contain line breaks
- detect multi-line labels by inspecting the value formatter

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68638979077c8322b34f6c4cd3ccd03f