### PR TITLE
Handle zoom scale priority

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/BarLineChartBaseManager.java
@@ -32,6 +32,7 @@ class ChartExtraProperties {
     public String identifier = null;
     public boolean syncX = true;
     public boolean syncY = false;
+    public Float zoomScaleX = null;
 }
 
 class ExtraPropertiesHolder {
@@ -148,6 +149,37 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
             }
         }
 
+        ChartExtraProperties extra = extraPropertiesHolder.getExtraProperties(chart);
+
+        if (extra.zoomScaleX != null) {
+            float targetScale = extra.zoomScaleX;
+            if (targetScale > 0 && chart.getScaleX() != targetScale) {
+                float relativeScale = targetScale / chart.getScaleX();
+                float centerX = chart.getData() != null ? (float) chart.getData().getXMax() : 0f;
+                YAxis.AxisDependency axis = chart.getAxisLeft().isEnabled() ?
+                        YAxis.AxisDependency.LEFT : YAxis.AxisDependency.RIGHT;
+                chart.zoom(relativeScale, 1f, centerX, 0f, axis);
+            }
+        } else {
+            ReadableMap saved = extra.savedVisibleRange;
+            if (saved != null && BridgeUtils.validate(saved, ReadableType.Map, "x")) {
+                ReadableMap xRange = saved.getMap("x");
+                if (BridgeUtils.validate(xRange, ReadableType.Number, "min")) {
+                    float minRange = (float) xRange.getDouble("min");
+                    if (minRange > 0) {
+                        float currentRange = chart.getVisibleXRange();
+                        if (currentRange > minRange) {
+                            float relativeScale = currentRange / minRange;
+                            float centerX = chart.getData() != null ? (float) chart.getData().getXMax() : 0f;
+                            YAxis.AxisDependency axis = chart.getAxisLeft().isEnabled() ?
+                                    YAxis.AxisDependency.LEFT : YAxis.AxisDependency.RIGHT;
+                            chart.zoom(relativeScale, 1f, centerX, 0f, axis);
+                        }
+                    }
+                }
+            }
+        }
+
         sendLoadCompleteEvent(chart);
     }
 
@@ -216,6 +248,8 @@ public abstract class BarLineChartBaseManager<T extends BarLineChartBase, U exte
                     (float) propMap.getDouble("yValue"),
                     axisDependency
             );
+
+            extraPropertiesHolder.getExtraProperties(chart).zoomScaleX = (float) propMap.getDouble("scaleX");
             sendLoadCompleteEvent(chart);
         }
     }


### PR DESCRIPTION
## Summary
- track `zoom.scaleX` in chart extra properties
- apply zoom scale first when updating visible range
- fallback to saved visible range minimum zoom if no zoom scale set

## Testing
- `yarn test` (no tests found)


------
https://chatgpt.com/codex/tasks/task_b_686cfae795048322addd695d6de28d8b