### PR TITLE
Handle zoom scale priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Triggered for various supported events on each platform. Due to the different na
 
 | Event Name | Description | iOS | Android |
 | --------------- | -------- | ------- | ---- |
-| `chartLoadComplete` | Fired after the chart renders or when zoom/visibleRange props update. | ✅ | ✅ |
+| `chartLoadComplete` | Fired after the chart initially renders or data is refreshed. | ✅ | ✅ |
 | `chartScaled`       | When a chart is scaled/zoomed via a pinch zoom gesture. | ✅ | ✅ |
 | `chartTranslated`   | When a chart is moved/translated via a drag gesture. | ✅ | ✅ |
 | `chartPanEnd`       | When a chart pan gesture ends. | ✅ | ❌ |
@@ -244,7 +244,7 @@ check Example->MultipleChart for details.
 ```jsx
 const handleChange = e => {
   if (e.nativeEvent.action === 'chartLoadComplete') {
-    // chart has applied zoom/visible range; scaleX/scaleY reflect the current state
+    // chart has finished rendering and data is ready
   }
 };
 <LineChart onChange={handleChange} ... />

--- a/docs.md
+++ b/docs.md
@@ -522,7 +522,7 @@ type combinedData {
 ```jsx
 const handleChange = e => {
   if (e.nativeEvent.action === 'chartLoadComplete') {
-    // zoom and visibleRange props have been applied; scaleX/scaleY are valid
+    // chart has finished rendering and data is ready
   }
 };
 <LineChart onChange={handleChange} ... />


### PR DESCRIPTION
## Summary
- track `zoom.scaleX` in chart extra properties
- apply zoom scale first when updating visible range
- fallback to saved visible range minimum zoom if no zoom scale set
- avoid sending `chartLoadComplete` when zoom props are applied
- fire `chartLoadComplete` when data is updated

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_686cfae795048322addd695d6de28d8b