### PR TITLE
Ensure chartLoadComplete fires on prop updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Triggered for various supported events on each platform. Due to the different na
 
 | Event Name | Description | iOS | Android |
 | --------------- | -------- | ------- | ---- |
-| `chartLoadComplete` | Fired after the chart initially renders or data is refreshed. | ✅ | ✅ |
+| `chartLoadComplete` | Fired after the chart initially renders or when chart data or axis props update. | ✅ | ✅ |
 | `chartScaled`       | When a chart is scaled/zoomed via a pinch zoom gesture. | ✅ | ✅ |
 | `chartTranslated`   | When a chart is moved/translated via a drag gesture. | ✅ | ✅ |
 | `chartPanEnd`       | When a chart pan gesture ends. | ✅ | ❌ |

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -762,8 +762,6 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
                 @Override
                 public boolean onPreDraw() {
                     chart.getViewTreeObserver().removeOnPreDrawListener(this);
-//                    sendLoadCompleteEvent(chart);
-//                    loadCompleteMap.put(chart, true);
                     chart.post(() -> {
                         sendLoadCompleteEvent(chart);
                         loadCompleteMap.put(chart, true);
@@ -771,6 +769,8 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
                     return true;
                 }
             });
+        } else {
+            chart.post(() -> sendLoadCompleteEvent(chart));
         }
     }
 

--- a/docs.md
+++ b/docs.md
@@ -522,7 +522,7 @@ type combinedData {
 ```jsx
 const handleChange = e => {
   if (e.nativeEvent.action === 'chartLoadComplete') {
-    // chart has finished rendering and data is ready
+    // chart has finished rendering or props were updated
   }
 };
 <LineChart onChange={handleChange} ... />

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -839,7 +839,13 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
         // chart.setNeedsLayout()
         // chart.layoutIfNeeded()
 
-        if !hasSentLoadComplete && bounds.width > 0 && bounds.height > 0 {
+        if hasSentLoadComplete {
+            if changedProps.contains("data") || changedProps.contains("xAxis") || changedProps.contains("yAxis") || changedProps.contains("valueFormatter") {
+                DispatchQueue.main.async { [weak self] in
+                    self?.sendEvent("chartLoadComplete")
+                }
+            }
+        } else if bounds.width > 0 && bounds.height > 0 {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 self.sendEvent("chartLoadComplete")


### PR DESCRIPTION
## Summary
- notify JS when datasets or axis props change
- document that `chartLoadComplete` fires after updates as well

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d0c611bb08322a0dd0727e5fa3fbd