### PR TITLE
Fix value/edge label zoom toggle

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/ChartBaseManager.java
@@ -520,7 +520,11 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
             axis.setEnabled(propMap.getBoolean("enabled"));
         }
         if (BridgeUtils.validate(propMap, ReadableType.Boolean, "drawLabels")) {
-            axis.setDrawLabels(propMap.getBoolean("drawLabels"));
+            boolean draw = propMap.getBoolean("drawLabels");
+            axis.setDrawLabels(draw);
+            if (chart instanceof BarLineChartBase && axis == chart.getXAxis()) {
+                com.github.wuxudong.rncharts.charts.helpers.EdgeLabelHelper.setUserDrawLabels((BarLineChartBase) chart, draw);
+            }
         }
         if (BridgeUtils.validate(propMap, ReadableType.Boolean, "drawAxisLine")) {
             axis.setDrawAxisLine(propMap.getBoolean("drawAxisLine"));

--- a/android/src/main/java/com/github/wuxudong/rncharts/charts/helpers/EdgeLabelHelper.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/charts/helpers/EdgeLabelHelper.java
@@ -21,6 +21,8 @@ public class EdgeLabelHelper {
     private static java.util.WeakHashMap<BarLineChartBase, Boolean> explicitMap = new java.util.WeakHashMap<>();
     // orientation override: null means auto-detect
     private static java.util.WeakHashMap<BarLineChartBase, Boolean> landscapeOverrideMap = new java.util.WeakHashMap<>();
+    // remembers user-specified drawLabels flag for xAxis
+    private static java.util.WeakHashMap<BarLineChartBase, Boolean> userDrawLabelsMap = new java.util.WeakHashMap<>();
     private static java.util.WeakHashMap<BarLineChartBase, float[]> baseOffsets = new java.util.WeakHashMap<>();
     private static java.util.WeakHashMap<BarLineChartBase, View.OnLayoutChangeListener> layoutListeners = new java.util.WeakHashMap<>();
     private static String leftTag(Chart chart) {
@@ -125,8 +127,9 @@ public class EdgeLabelHelper {
         int padLeft = px(chart, PADDING_DP_LEFT);
         int padRight = px(chart, PADDING_DP_RIGHT);
 
-        left.layout(chartLeft + padLeft, chartBottom - leftH + 8, chartLeft + padLeft + leftW, chartBottom);
-        right.layout(chartRight - rightW - padRight, chartBottom - rightH + 8, chartRight - padRight, chartBottom);
+        int overlayH = overlayHeight(chart);
+        left.layout(chartLeft + padLeft, chartBottom - overlayH, chartLeft + padLeft + leftW, chartBottom);
+        right.layout(chartRight - rightW - padRight, chartBottom - overlayH, chartRight - padRight, chartBottom);
 
         left.bringToFront();
         right.bringToFront();
@@ -220,7 +223,7 @@ public class EdgeLabelHelper {
         float[] b = base(chart);
         float bottom = b[3];
         if (isEnabled(chart)) {
-            bottom = (float) overlayHeight(chart) / 2f;
+            bottom = b[3] + (float) overlayHeight(chart);
         }
         chart.setExtraOffsets(b[0], b[1], b[2], bottom);
     }
@@ -251,5 +254,19 @@ public class EdgeLabelHelper {
     /** Returns landscape override if provided; otherwise null. */
     public static java.lang.Boolean getLandscapeOverride(BarLineChartBase chart) {
         return landscapeOverrideMap.get(chart);
+    }
+
+    /** Remembers user-specified drawLabels flag for xAxis. */
+    public static void setUserDrawLabels(BarLineChartBase chart, java.lang.Boolean enabled) {
+        if (enabled == null) {
+            userDrawLabelsMap.remove(chart);
+        } else {
+            userDrawLabelsMap.put(chart, enabled);
+        }
+    }
+
+    /** Returns user-specified drawLabels flag for xAxis, or null if not provided. */
+    public static java.lang.Boolean getUserDrawLabels(BarLineChartBase chart) {
+        return userDrawLabelsMap.get(chart);
     }
 }

--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -116,17 +116,18 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
         }
 
         XAxis axis = chart.getXAxis();
-        boolean labelsDisabled = !axis.isDrawLabelsEnabled();
+        Boolean userDraw = EdgeLabelHelper.getUserDrawLabels(chart);
+        boolean userDisabledLabels = userDraw != null && !userDraw.booleanValue();
 
         Boolean explicit = EdgeLabelHelper.getExplicitFlag(chart);
         boolean desiredEdge;
         if (explicit != null) {
-            desiredEdge = labelsDisabled ? true : explicit.booleanValue();
+            desiredEdge = userDisabledLabels ? true : explicit.booleanValue();
         } else {
-            desiredEdge = labelsDisabled ? true : !showValues;
+            desiredEdge = userDisabledLabels ? true : !showValues;
         }
 
-        if (explicit == null && !labelsDisabled) {
+        if (explicit == null && userDraw == null) {
             axis.setDrawLabels(showValues);
         }
 


### PR DESCRIPTION
## Summary
- track user drawLabels setting for xAxis
- toggle drawLabels only when user hasn't provided a value
- show or hide edge labels correctly when zooming
- correct Android edge label positioning so text is not clipped

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: package not in lockfile)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_686d4136e62083228a297bb9e3de2fcc