### PR TITLE
Fix edge label padding

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -61,6 +61,7 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
 
     @Override
     public void onChartGestureEnd(MotionEvent me, ChartTouchListener.ChartGesture lastPerformedGesture) {
+        adjustValueAndEdgeLabels();
         sendEvent("chartGestureEnd", me);
     }
 
@@ -151,9 +152,7 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
         }
 
         boolean showAxis = desiredEdge ? false : showValues;
-        if (explicit == null && userDraw == null) {
-            axis.setDrawLabels(showAxis);
-        }
+        axis.setDrawLabels(showAxis);
 
         EdgeLabelHelper.setEnabled(chart, desiredEdge);
         EdgeLabelHelper.applyPadding(chart);

--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -282,7 +282,7 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
             if xAxisContainsNewline() {
                 axisHeight = barLineChart.xAxis.labelFont.lineHeight
             }
-            bottom = axisHeight + edgeLabelHeight()
+            bottom += axisHeight + edgeLabelHeight() / 2
         }
 
         barLineChart.setExtraOffsets(left: left, top: top, right: right, bottom: bottom)

--- a/ios/ReactNativeCharts/RNChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNChartViewBase.swift
@@ -703,6 +703,9 @@ open class RNChartViewBase: UIView, ChartViewDelegate {
     private func configureEdgeLabels(_ enable: Bool) {
         edgeLabelEnabled = enable
         if enable {
+            if let barLine = chart as? BarLineChartViewBase {
+                barLine.xAxis.drawLabelsEnabled = false
+            }
             if leftEdgeLabel == nil {
                 let label = UILabel()
                 label.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## Summary
- adjust extra bottom padding calculation for edge labels on iOS
- disable axis labels whenever edge labels are enabled
- update Android gesture listener to reapply label logic before `chartGestureEnd`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d4d93d94c832285f2bbaf99366621