### PR TITLE
Fix iOS visible range zoom

### DIFF
--- a/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
+++ b/ios/ReactNativeCharts/RNBarLineChartViewBase.swift
@@ -112,6 +112,9 @@ class RNBarLineChartViewBase: RNYAxisChartViewBase {
     func setVisibleRange(_ config: NSDictionary) {
         // delay visibleRange handling until chart data is set
         savedVisibleRange = config
+        if barLineChart.data != nil {
+            updateVisibleRange(config)
+        }
     }
 
     func updateVisibleRange(_ config: NSDictionary) {


### PR DESCRIPTION
## Summary
- ensure `visibleRange` is applied immediately when the chart already has data on iOS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686d6a100ac88322b9321aa69cc097b0