### PR TITLE
Fix marker overlay reset

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/markers/RNAtfleeMarkerView.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/markers/RNAtfleeMarkerView.java
@@ -303,10 +303,7 @@ public class RNAtfleeMarkerView extends MarkerView {
         Log.d("RNAtfleeMarkerView", "Sending event topMarkerClick");
         reactContext.getJSModule(RCTEventEmitter.class)
                 .receiveEvent(chart.getId(), "topMarkerClick", event);
-        // Clear the current highlight without triggering listeners and
-        // then reset marker-related state as done on iOS.
-        chart.highlightValue(null);
-        chart.invalidate();
+        // Inform JS about the marker click, then clear state to hide the marker
         resetState();
     }
 
@@ -358,6 +355,15 @@ public class RNAtfleeMarkerView extends MarkerView {
 
     public void resetState() {
         fadeStart = 0L;
+        lastEntry = null;
+
+        Chart chart = getChartView();
+        if (chart != null) {
+            // Clear the current highlight and redraw the chart
+            chart.highlightValue(null);
+            chart.invalidate();
+        }
+
         removeOverlayButton();
     }
 


### PR DESCRIPTION
## Summary
- clear highlights using `chart.highlightValue(null)` when resetting marker state

## Testing
- `npm test` *(fails: Missing script)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_686d6821778c83228738eb0c6e560e90