### PR TITLE
fix(android): prevent false marker click events

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -21,6 +21,7 @@ import com.github.mikephil.charting.data.ChartData;
 import com.github.mikephil.charting.interfaces.datasets.IDataSet;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.highlight.Highlight;
+import com.github.mikephil.charting.utils.MPPointF;
 import com.github.wuxudong.rncharts.markers.RNAtfleeMarkerView;
 import java.util.WeakHashMap;
 
@@ -86,9 +87,19 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
                 RNAtfleeMarkerView marker = (RNAtfleeMarkerView) barChart.getMarker();
                 Highlight h = barChart.getHighlightByTouchPoint(me.getX(), me.getY());
                 if (h != null) {
-                    // forward to marker click handler
-                    marker.dispatchClick();
-                    return; // do not emit generic single tap
+                    float markerWidth = marker.getWidth() > 0 ? marker.getWidth() : marker.getMeasuredWidth();
+                    float markerHeight = marker.getHeight() > 0 ? marker.getHeight() : marker.getMeasuredHeight();
+                    if (markerWidth > 0 && markerHeight > 0) {
+                        MPPointF offset = marker.getOffsetForDrawingAtPoint(h.getDrawX(), h.getDrawY());
+                        float left = h.getDrawX() + offset.x;
+                        float top = h.getDrawY() + offset.y;
+                        float right = left + markerWidth;
+                        float bottom = top + markerHeight;
+                        if (me.getX() >= left && me.getX() <= right && me.getY() >= top && me.getY() <= bottom) {
+                            marker.dispatchClick();
+                            return;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- detect taps within the marker's bounds before triggering `onMarkerClick`
- avoid false positives when tapping elsewhere on the chart

## Testing
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_b_689c9ee2420c8322a51f801e6b7f589b