### PR TITLE
fix(android): prevent false marker click events

### DIFF
--- a/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
+++ b/android/src/main/java/com/github/wuxudong/rncharts/listener/RNOnChartGestureListener.java
@@ -21,6 +21,7 @@ import com.github.mikephil.charting.data.ChartData;
 import com.github.mikephil.charting.interfaces.datasets.IDataSet;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.highlight.Highlight;
+import com.github.mikephil.charting.utils.MPPointF;
 import com.github.wuxudong.rncharts.markers.RNAtfleeMarkerView;
 import java.util.WeakHashMap;
 
@@ -84,11 +85,24 @@ public class RNOnChartGestureListener implements OnChartGestureListener {
             BarLineChartBase barChart = (BarLineChartBase) chart;
             if (barChart.getMarker() instanceof RNAtfleeMarkerView) {
                 RNAtfleeMarkerView marker = (RNAtfleeMarkerView) barChart.getMarker();
-                Highlight h = barChart.getHighlightByTouchPoint(me.getX(), me.getY());
-                if (h != null) {
-                    // forward to marker click handler
-                    marker.dispatchClick();
-                    return; // do not emit generic single tap
+                Highlight[] highlights = barChart.getHighlighted();
+                if (highlights != null && highlights.length > 0) {
+                    Highlight h = highlights[0];
+                    float markerWidth = marker.getWidth() > 0 ? marker.getWidth() : marker.getMeasuredWidth();
+                    float markerHeight = marker.getHeight() > 0 ? marker.getHeight() : marker.getMeasuredHeight();
+                    if (markerWidth > 0 && markerHeight > 0) {
+                        float posX = h.getXPx();
+                        float posY = h.getYPx();
+                        MPPointF offset = marker.getOffsetForDrawingAtPoint(posX, posY);
+                        float left = posX + offset.x;
+                        float top = posY + offset.y;
+                        float right = left + markerWidth;
+                        float bottom = top + markerHeight;
+                        if (me.getX() >= left && me.getX() <= right && me.getY() >= top && me.getY() <= bottom) {
+                            marker.dispatchClick();
+                            return;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- detect taps within the marker's bounds before triggering `onMarkerClick`
- rely on the chart's current highlight so taps inside the marker properly dispatch
- compute marker bounds using highlight coordinates to avoid protected `getMarkerPosition`

## Testing
- `npm test` (fails: Missing script)
- `cd android && ./gradlew assembleDebug` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_b_689c9ee2420c8322a51f801e6b7f589b